### PR TITLE
Implement config module

### DIFF
--- a/antenna/configlib.py
+++ b/antenna/configlib.py
@@ -1,0 +1,323 @@
+"""This module contains the configuration infrastructure allowing for deriving
+configuration from a .ini file and the process environment.
+
+In order of precedence:
+
+1. settings overrides (usually only applies when running tests)
+2. process environment
+3. .ini file (specified by ANTENNA_INI environment variable)
+
+Example of usage::
+
+    from antenna.configlib import config
+
+    DEBUG = config('DEBUG', default=True, parser='bool')
+
+
+This also makes it easy to do testing using the settings_override
+decorator::
+
+    from antenna.configlib import settings_override
+
+    @settings_override(FOO='bar', BAZ='bat')
+    def test_this():
+        ...
+
+
+Wait--what? Why'd write our own configuration library when there are so many
+out there?
+
+I wanted one that was flexible, supported namespaces and it needed to be easy
+to test with. That meant it needed to work with overrides and it needed to
+compose nicely. I wanted something with namespaces so that I could have two
+instances of the same component with two different configurations.
+
+"""
+
+import inspect
+import os
+import urlparse
+from ConfigParser import SafeConfigParser as ConfigParser
+from functools import wraps
+
+
+# This is a stack of overrides to be examined in reverse order
+_CONFIG_OVERRIDE = []
+
+
+# Singleton indicating a non-value
+NO_VALUE = object()
+
+
+def parse_bool(val):
+    """Parses a bool
+
+    Handles a series of values, but you should probably standardize on
+    "true" and "false".
+
+    """
+    true_vals = ('t', 'true', 'yes', 'y', '1')
+    false_vals = ('f', 'false', 'no', 'n', '0')
+
+    val = val.lower()
+    if val in true_vals:
+        return True
+    if val in false_vals:
+        return False
+
+    raise ValueError('%s is not a valid bool value' % val)
+
+
+def get_parser(parser):
+    """Returns a parsing function for a given parser"""
+    # Special case bool so that we can explicitly give bool values otherwise
+    # all values would be True since they're non-empty strings.
+    if parser is bool:
+        return parse_bool
+    return parser
+
+
+class ListOf(object):
+    def __init__(self, parser, delimiter=','):
+        self.sub_parser = parser
+        self.delimiter = delimiter
+
+    def __call__(self, value):
+        parser = get_parser(self.sub_parser)
+        return [parser(token) for token in value.split(self.delimiter)]
+
+
+class ConfigurationError(Exception):
+    pass
+
+
+class ConfigOverrideEnv(object):
+    """Override configuration layer for testing"""
+    def get(self, key, namespace=''):
+        if namespace:
+            key = '%s_%s' % (namespace, key)
+
+        key = key.upper()
+
+        for env in reversed(_CONFIG_OVERRIDE):
+            if key in env:
+                return env[key]
+        return NO_VALUE
+
+
+class ConfigDictEnv(object):
+    """dict-based configuration layer
+
+    Namespace is prefixed, so key "foo" in namespace "bar" is ``FOO_BAR``.
+
+    """
+    def __init__(self, cfg):
+        self.cfg = cfg
+
+    def get(self, key, namespace=''):
+        if namespace:
+            key = '%s_%s' % (namespace, key)
+        key = key.upper()
+
+        if key in self.cfg:
+            return self.cfg[key]
+        return NO_VALUE
+
+
+class ConfigOSEnv(object):
+    """os.environ derived configuration layer
+
+    Namespace is prefixed, so key "foo" in namespace "bar" is ``FOO_BAR`` in
+    the ``os.environ``.
+
+    """
+    def get(self, key, namespace=''):
+        if namespace:
+            key = '%s_%s' % (namespace, key)
+
+        key = key.upper()
+        if key in os.environ:
+            return os.environ[key]
+
+        return NO_VALUE
+
+
+class ConfigIniEnv(object):
+    """.ini style configuration layer
+
+    Namespace is a config section. So "foo" in namespace "bar" is::
+
+        [bar]
+        foo=someval
+
+    """
+    def __init__(self, fn):
+        self._parser = ConfigParser()
+        self._parser.readfp(open(fn, 'r'))
+
+    def get(self, key, namespace='main'):
+        if self._parser.has_option(namespace, key):
+            return self._parser.get(namespace, key)
+        return NO_VALUE
+
+
+class ConfigManager(object):
+    """Manages multiple configuration environment layers"""
+    def __init__(self):
+        self.envs = self._initialize_environments()
+
+    def _initialize_environments(self):
+        # Add environments in order of precedence--first is the most important!
+        envs = []
+
+        # Add override environment
+        envs.append(ConfigOverrideEnv())
+
+        # Add OS environment
+        envs.append(ConfigOSEnv())
+
+        # Add .ini environment
+        fn = os.environ.get('ANTENNA_INI', 'antenna.ini')
+        if not os.sep in fn:
+            fn = os.path.join(os.getcwd(), fn)
+        if os.path.exists(fn):
+            envs.append(ConfigIniEnv(fn))
+
+        return envs
+
+    def __call__(self, key, namespace=None, default=NO_VALUE, parser=str,
+                 raise_error=False):
+        """Returns a parsed value from the environment
+
+        :arg key: the key to look up
+        :arg namespace: the namespace for the key--different environments
+            use this differently
+        :arg default: the default value (if any)
+        :arg parser: the parser for converting this value to a Python object
+        :arg raise_error: True if you want a lack of value to raise a
+            ``ConfigurationError``
+
+        Examples::
+
+            # Use the special bool parser
+            DEBUG = config('DEBUG', default=True, parser=bool)
+
+            from antenna.config_util import ListOf
+            ALLOWED_HOSTS = config('ALLOWED_HOSTS', default='localhost',
+                                   parser=ListOf(str))
+
+        """
+        parser = get_parser(parser)
+
+        # Go through environments in reverse order
+        for env in self.envs:
+            val = env.get(key, namespace)
+            if val is not NO_VALUE:
+                return parser(val)
+
+        # Return the default if there is one
+        if default is not NO_VALUE:
+            return parser(default)
+
+        # No value specified and no default, so raise an error to the user
+        if raise_error:
+            raise ConfigurationError(
+                '%s (%s) requires a value of type %s' % (key, namespace, parser)
+            )
+
+        # Otherwise return None
+        return
+
+
+class ConfigManagerWrapper(object):
+    """Wraps the config manager so it's easier to set the config
+
+    This prevents the problem where Python modules load "config"
+    into their name space and then you have to do weird things to
+    fix that. Instead, you call ``config.set_config(CM)`` and pass
+    in a new ConfigManager and you're all set.
+
+    """
+    def __init__(self):
+        self.config = ConfigManager()
+
+    def set_config(self, config):
+        self.config = config
+
+    def __call__(self, *args, **kwargs):
+        return self.config.__call__(*args, **kwargs)
+
+
+# Use this when you're doing config things
+config = ConfigManagerWrapper()
+
+
+class ConfigOverride(object):
+    """Allows you to override config for tests
+
+    This can be used as a class decorator::
+
+        @config_override(FOO='bar', BAZ='bat')
+        class FooTestClass(object):
+            ...
+
+
+    This can be used as a function decorator::
+
+        @config_override(FOO='bar')
+        def test_foo():
+            ...
+
+
+    This can also be used as a context manager::
+
+        def test_foo():
+            with config_override(FOO='bar'):
+                ...
+
+    """
+    def __init__(self, **cfg):
+        self._cfg = cfg
+
+    def push_config(self):
+        _CONFIG_OVERRIDE.append(self._cfg)
+
+    def pop_config(self):
+        # Make sure it's not empty already because if it is, then we've done
+        # something horribly wrong.
+        assert _CONFIG_OVERRIDE
+        _CONFIG_OVERRIDE.pop()
+
+    def __enter__(self):
+        self.push_config()
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.pop_config()
+
+    def decorate(self, fun):
+        @wraps(fun)
+        def _decorated(*args, **kwargs):
+            # Push the config, run the function and pop it afterwards.
+            self.push_config()
+            try:
+                return fun(*args, **kwargs)
+            finally:
+                self.pop_config()
+        return _decorated
+
+    def __call__(self, class_or_fun):
+        if inspect.isclass(class_or_fun):
+            # If class_or_fun is a class, decorate all of its methods
+            # that start with 'test'.
+            for attr in class_or_fun.__dict__.keys():
+                prop = getattr(class_or_fun, attr)
+                if attr.startswith('test') and callable(prop):
+                    setattr(func_or_class, attr, self.decorate(prop))
+            return func_or_class
+
+        else:
+            return self.decorate(class_or_fun)
+
+
+# This gives it a better name
+config_override = ConfigOverride

--- a/tests/data/config_test.ini
+++ b/tests/data/config_test.ini
@@ -1,0 +1,5 @@
+[main]
+foo = bar
+
+[namespacebaz]
+foo = bat

--- a/tests/test_configlib.py
+++ b/tests/test_configlib.py
@@ -1,0 +1,115 @@
+import os
+
+import mock
+import pytest
+
+from antenna.configlib import (
+    config,
+    config_override,
+    ConfigDictEnv,
+    ConfigIniEnv,
+    ConfigOSEnv,
+    ConfigurationError,
+    get_parser,
+    parse_bool,
+    ListOf,
+)
+
+
+def test_parse_bool_error():
+    with pytest.raises(ValueError):
+        parse_bool('')
+
+
+@pytest.mark.parametrize('data', [
+    't',
+    'true',
+    'True',
+    'TRUE',
+    'y',
+    'yes',
+    'YES',
+    '1',
+])
+def test_parse_bool_true(data):
+    assert parse_bool(data) == True
+
+
+@pytest.mark.parametrize('data', [
+    'f',
+    'false',
+    'False',
+    'FALSE',
+    'n',
+    'no',
+    'No',
+    'NO',
+    '0',
+])
+def test_parse_bool_false(data):
+    assert parse_bool(data) == False
+
+
+def test_get_parser():
+    assert get_parser(bool) == parse_bool
+    assert get_parser(str) == str
+    foo = lambda val: val
+    assert get_parser(foo) == foo
+
+
+def test_ListOf():
+    assert ListOf(str)('foo') == ['foo']
+    assert ListOf(bool)('t,f') == [True, False]
+    assert ListOf(int)('1,2,3') == [1, 2, 3]
+    assert ListOf(int, delimiter=':')('1:2') == [1, 2]
+
+
+def test_ConfigDictEnv():
+    cde = ConfigDictEnv({'FOO': 'bar', 'NAMESPACE_FOO': 'baz'})
+    assert cde.get('foo') == 'bar'
+    assert cde.get('foo', namespace='namespace') == 'baz'
+
+
+def test_ConfigOSEnv():
+    with mock.patch('os.environ') as os_environ_mock:
+        os_environ_mock.__contains__.return_value = True
+        os_environ_mock.__getitem__.return_value = 'baz'
+        cose = ConfigOSEnv()
+        assert cose.get('foo') == 'baz'
+        os_environ_mock.__getitem__.assert_called_with('FOO')
+
+
+    with mock.patch('os.environ') as os_environ_mock:
+        os_environ_mock.__contains__.return_value = True
+        os_environ_mock.__getitem__.return_value = 'baz'
+        cose = ConfigOSEnv()
+        assert cose.get('foo', namespace='namespace') == 'baz'
+        os_environ_mock.__getitem__.assert_called_with('NAMESPACE_FOO')
+
+
+def test_ConfigIniEnv(datadir):
+    ini_filename = os.path.join(datadir, 'config_test.ini')
+    cie = ConfigIniEnv(ini_filename)
+    assert cie.get('foo') == 'bar'
+    assert cie.get('foo', namespace='namespacebaz') == 'bat'
+
+
+def test_config():
+    assert config('DOESNOTEXISTNOWAY') == None
+    with pytest.raises(ConfigurationError):
+        config('DOESNOTEXISTNOWAY', raise_error=True)
+    assert config('DOESNOTEXISTNOWAY', default='ohreally') == 'ohreally'
+
+
+def test_config_override():
+    # Make sure the key doesn't exist
+    assert config('DOESNOTEXISTNOWAY') == None
+
+    # Try one override
+    with config_override(DOESNOTEXISTNOWAY='bar'):
+        assert config('DOESNOTEXISTNOWAY') == 'bar'
+
+    # Try nested overrides--innermost one rules supreme!
+    with config_override(DOESNOTEXISTNOWAY='bar'):
+        with config_override(DOESNOTEXISTNOWAY='bat'):
+            assert config('DOESNOTEXISTNOWAY') == 'bat'


### PR DESCRIPTION
This is similar in some ways to python-decouple, but it does things I needed it to do:

1. namespaces for configuration: makes it easier to have multiple components use configuration
2. configuration overrides for testing: makes it possible to test various configuration modes in tests
3. allows for adjusting configuration precedence: I'm not sure I need this for antenna, but it seemed generally useful

This supports .ini files and process environment configuration. It supports parsing strings into Python objects in a variety of different ways.

The one thing this doesn't do is automatic documentation generation. I'd really like to be able to point Sphinx at something that uses this configuration module and have it slurp all the configuration information and expose it in the docs without me having to do anything.

This is probably good enough for now.

r?