### PR TITLE
Modify config

### DIFF
--- a/antenna/configlib.py
+++ b/antenna/configlib.py
@@ -32,7 +32,7 @@ Example for secrets::
 
     config = ConfigManager()
 
-SECRET_KEY = config('SECRET_KEY')
+    SECRET_KEY = config('SECRET_KEY')
 
 
 If the ``SECRET_KEY`` is not provided, then this will raise a configuration

--- a/antenna/configlib.py
+++ b/antenna/configlib.py
@@ -13,7 +13,9 @@ In order of precedence:
 
 Example of usage::
 
-    from antenna.configlib import config
+    from antenna.configlib import ConfigManager
+
+    config = ConfigManager()
 
     DEBUG = config('DEBUG', default='True', parser=bool)
 
@@ -28,7 +30,9 @@ Example for secrets::
 
     from antenna.configlib import config
 
-    SECRET_KEY = config('SECRET_KEY')
+    config = ConfigManager()
+
+SECRET_KEY = config('SECRET_KEY')
 
 
 If the ``SECRET_KEY`` is not provided, then this will raise a configuration
@@ -229,6 +233,8 @@ class ConfigManager(object):
 
         Examples::
 
+            config = ConfigManager()
+
             # Use the special bool parser
             DEBUG = config('DEBUG', default='True', parser=bool)
 
@@ -263,29 +269,6 @@ class ConfigManager(object):
 
         # Otherwise return None
         return
-
-
-class ConfigManagerWrapper(object):
-    """Wraps the config manager so it's easier to set the config
-
-    This prevents the problem where Python modules load "config"
-    into their name space and then you have to do weird things to
-    fix that. Instead, you call ``config.set_config(CM)`` and pass
-    in a new ConfigManager and you're all set.
-
-    """
-    def __init__(self):
-        self.config = ConfigManager()
-
-    def set_config(self, config):
-        self.config = config
-
-    def __call__(self, *args, **kwargs):
-        return self.config.__call__(*args, **kwargs)
-
-
-# Use this when you're doing config things
-config = ConfigManagerWrapper()
 
 
 class ConfigOverride(object):

--- a/antenna/configlib.py
+++ b/antenna/configlib.py
@@ -62,6 +62,7 @@ class and function decorator::
 
 """
 
+import importlib
 import inspect
 import os
 from ConfigParser import SafeConfigParser as ConfigParser
@@ -82,6 +83,11 @@ def parse_bool(val):
     Handles a series of values, but you should probably standardize on
     "true" and "false".
 
+    >>> parse_bool('y')
+    True
+    >>> parse_bool('FALSE')
+    False
+
     """
     true_vals = ('t', 'true', 'yes', 'y', '1')
     false_vals = ('f', 'false', 'no', 'n', '0')
@@ -93,6 +99,22 @@ def parse_bool(val):
         return False
 
     raise ValueError('%s is not a valid bool value' % val)
+
+
+def parse_class(val):
+    """Parses a string, imports the module and returns the class
+
+    >>> parse_class('hashlib.md5')
+
+    """
+    module, class_name = val.rsplit('.', 1)
+    module = importlib.import_module(module)
+    try:
+        return getattr(module, class_name)
+    except AttributeError:
+        raise ValueError('%s is not a valid member of %s' % (
+            class_name, module)
+        )
 
 
 def get_parser(parser):

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -22,7 +22,10 @@ def generate_basic_auth_token(username, password):
 
 class Test_required_basic_auth:
     class FakeResource(object):
-        @require_basic_auth('gooduser', 'goodpwd')
+        def is_valid_auth(self, username, password):
+            return (username, password) == ('gooduser', 'goodpwd')
+
+        @require_basic_auth
         def on_get(self, req, resp):
             return
 

--- a/tests/test_configlib.py
+++ b/tests/test_configlib.py
@@ -16,6 +16,7 @@ from antenna.configlib import (
     ConfigurationError,
     get_parser,
     parse_bool,
+    parse_class,
     ListOf,
 )
 
@@ -52,6 +53,19 @@ def test_parse_bool_true(data):
 ])
 def test_parse_bool_false(data):
     assert parse_bool(data) is False
+
+
+def test_parse_missing_class():
+    with pytest.raises(ImportError):
+        parse_class('doesnotexist.class')
+
+    with pytest.raises(ValueError):
+        parse_class('hashlib.doesnotexist')
+
+
+def test_parse_class():
+    from hashlib import md5
+    assert parse_class('hashlib.md5') == md5
 
 
 def test_get_parser():

--- a/tests/test_configlib.py
+++ b/tests/test_configlib.py
@@ -8,7 +8,6 @@ import mock
 import pytest
 
 from antenna.configlib import (
-    config,
     config_override,
     ConfigDictEnv,
     ConfigIniEnv,
@@ -115,6 +114,8 @@ def test_config_ini_file_does_not_exist():
 
 
 def test_config():
+    config = ConfigManager()
+
     assert config('DOESNOTEXISTNOWAY', raise_error=False) is None
     with pytest.raises(ConfigurationError):
         config('DOESNOTEXISTNOWAY')
@@ -124,6 +125,8 @@ def test_config():
 
 
 def test_config_override():
+    config = ConfigManager()
+
     # Make sure the key doesn't exist
     assert config('DOESNOTEXISTNOWAY', raise_error=False) is None
 
@@ -138,5 +141,7 @@ def test_config_override():
 
 
 def test_default_must_be_string():
+    config = ConfigManager()
+
     with pytest.raises(ConfigurationError):
         assert config('DOESNOTEXIST', default=True)


### PR DESCRIPTION
This tweaks configuration a little bit to make it easier to work with in the breakpad code I'm writing.

The only new feature is the `parse_class` parser. That should be pretty straight-forward.

The rest of it is nixing the config singleton for one that's instantiated when the app is created.