### PR TITLE
Dockerfile updated to be based on python, circle building properly

### DIFF
--- a/bin/ci/deploy-dockerhub.sh
+++ b/bin/ci/deploy-dockerhub.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# THIS IS MEANT TO BE RUN BY CI
+
+set -e
+
+# Usage: retry MAX CMD...
+# Retry CMD up to MAX times. If it fails MAX times, returns failure.
+# Example: retry 3 docker push "mozilla/antenna:$TAG"
+function retry() {
+    max=$1
+    shift
+    count=1
+    until "$@"; do
+        count=$((count + 1))
+        if [[ $count -gt $max ]]; then
+            return 1
+        fi
+        echo "$count / $max"
+    done
+    return 0
+}
+
+# configure docker creds
+retry 3 docker login -e="$DOCKER_EMAIL" -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
+
+# docker tag and push git branch to dockerhub
+if [ -n "$1" ]; then
+    [ "$1" == master ] && TAG=latest || TAG="$1"
+    docker tag antenna:build "mozilla/antenna:$TAG" ||
+        (echo "Couldn't tag antenna:build as mozilla/antenna:$TAG" && false)
+    retry 3 docker push "mozilla/antenna:$TAG" ||
+        (echo "Couldn't push mozilla/antenna:$TAG" && false)
+    echo "Pushed mozilla/antenna:$TAG"
+fi

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,63 @@
+machine:
+  services:
+    - docker
+
+dependencies:
+  cache_directories:
+    - "~/cache/"
+  override:
+    # create a version.json per https://github.com/mozilla-services/Dockerflow/blob/master/docs/version_object.md
+    - >
+        printf '{"commit":"%s","version":"%s","source":"https://github.com/%s/%s","build":"%s"}\n'
+        "$CIRCLE_SHA1"
+        "$CIRCLE_TAG"
+        "$CIRCLE_PROJECT_USERNAME"
+        "$CIRCLE_PROJECT_REPONAME"
+        "$CIRCLE_BUILD_URL" > version.json
+    - cp version.json $CIRCLE_ARTIFACTS
+    - docker info
+    # use circleci's docker cache workaround
+    - mkdir -p ~/cache/
+    - if [ -e ~/cache/docker/image.tar ]; then echo "Loading image.tar"; docker load -i ~/cache/docker/image.tar || rm ~/cache/docker/image.tar; fi
+    # build image
+    - docker build -t antenna:build .
+    # Clean up old image and save the new one
+    - >
+      mkdir -p ~/cache/docker;
+      rm -f ~/cache/docker/image.tar;
+      docker save antenna:build > ~/cache/docker/image.tar;
+      ls -l ~/cache/docker
+
+test:
+  pre:
+    - chmod -R 777 $CIRCLE_TEST_REPORTS
+    - pip install tox
+  override:
+    # Run Python tests
+    - tox -e flake8
+    - tox -e tests
+
+# appropriately tag and push the container to dockerhub
+deployment:
+  latest:
+    branch: master
+    commands:
+      # set DOCKER_DEPLOY=true in Circle UI to do deploys
+      - "${DOCKER_DEPLOY:-false}"
+      - bin/ci/deploy-dockerhub.sh latest
+
+  tags:
+    # push all tags
+    tag: /.*/
+    commands:
+      # set DOCKER_DEPLOY=true in Circle UI to do deploys
+      - "${DOCKER_DEPLOY:-false}"
+      - bin/ci/deploy-dockerhub.sh "$CIRCLE_TAG"
+
+  # this is just for dev / testing
+  hub_all:
+    branch: /.*/
+    commands:
+      # set DOCKER_DEPLOY=true in Circle UI to do deploys
+      - "${DOCKER_DEPLOY:-false}"
+      - bin/ci/deploy-dockerhub.sh unstable


### PR DESCRIPTION
update dockerfile to be based on python:2.7.12-slim, add circle.yml and boilerplate for building containers in circle

@willkg r+?

You can pull from dockerhub with `docker pull mozilla/antenna:unstable`. Once this is merged you can just `docker pull mozilla/antenna` and it will pull latest, which is built off of master.

:unstable will be built off of the latest non-master, non-tagged build (on any branch of _this_ repo)