### PR TITLE
Implement FSCrashStore

### DIFF
--- a/antenna/app.py
+++ b/antenna/app.py
@@ -189,6 +189,9 @@ class BreakpadSubmitterResource(RequiredConfigMixin):
             elif isinstance(val, bytes):
                 # This is a dump, so we get a checksum and save the bits in the
                 # relevant places.
+
+                # FIXME(willkg): The dump name is essentially user-provided. We should
+                # sanitize it before proceeding.
                 dumps[key] = val
                 checksum = hashlib.md5(val).hexdigest()
                 raw_crash.setdefault('dump_checksums', {})[key] = checksum
@@ -218,6 +221,8 @@ class BreakpadSubmitterResource(RequiredConfigMixin):
             raw_crash['uuid'] = crash_id
             logger.info('%s received', crash_id)
         else:
+            # FIXME(willkg): This means the uuid is essentially user-provided.
+            # We should sanitize it before proceeding.
             crash_id = raw_crash['uuid']
             logger.info('%s received with existing crash_id:', crash_id)
 

--- a/antenna/external/crashstorage_base.py
+++ b/antenna/external/crashstorage_base.py
@@ -14,7 +14,15 @@ class CrashStorageBase:
         pass
 
     def save_raw_crash(self, raw_crash, dumps, crash_id):
-        """Saves the raw crash and related dumps"""
+        """Saves the raw crash and related dumps
+
+        FIXME(willkg): How should this method handle exceptions?
+
+        :arg raw_crash: dict The raw crash as a dict.
+        :arg dumps: Map of dump name (e.g. ``upload_file_minidump``) to dump contents.
+        :arg crash_id: The crash id as a string.
+
+        """
         raise NotImplementedError
 
 

--- a/antenna/external/fs/__init__.py
+++ b/antenna/external/fs/__init__.py
@@ -1,0 +1,3 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.

--- a/antenna/external/fs/crashstorage.py
+++ b/antenna/external/fs/crashstorage.py
@@ -1,0 +1,132 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import logging
+import os
+import os.path
+
+from everett.component import ConfigOptions, RequiredConfigMixin
+
+from antenna.util import json_ordered_dumps
+
+
+logger = logging.getLogger(__name__)
+
+
+class FSCrashStorage(RequiredConfigMixin):
+    """Saves raw crash files to the file system
+
+    This generates a tree something like this which mirrors what we do
+    on S3:
+
+    ::
+
+        <FS_ROOT>/
+            <YYYYMMDD>/
+                raw_crash/
+                    <CRASHID>.json
+                dump_names/
+                    <CRASHID>.json
+                <DUMP_NAME>/
+                    <CRASHID>
+
+
+    Couple of things to note:
+
+    1. This doesn't ever delete anything from the tree. You should run another
+       process to clean things up.
+
+    2. If you run out of disk space, this component will fail miserably.
+       There's no way to recover from a full disk--you will lose crashes.
+
+    FIXME(willkg): Can we alleviate or reduce the likelihood of the above?
+
+    """
+    required_config = ConfigOptions()
+    required_config.add_option(
+        'fs_root',
+        default='/tmp/antenna_crashes',
+        doc='path to where files should be stored'
+    )
+
+    # FIXME(willkg): umask
+
+    def __init__(self, config):
+        self.config = config.with_options(self)
+
+        self.root = os.path.abspath(self.config('fs_root'))
+        # FIXME(willkg): We should probably do more to validate fs_root. Remove
+        # / at the end? Verify we can write files to it?
+        if not os.path.isdir(self.root):
+            os.makedirs(self.root)
+
+    def _get_crash_date(self, crash_id):
+        # NOTE(willkg): This assumes we're in the 21st century and that the last
+        # six characters of the crash_id are YYMMDD.
+        return '20' + crash_id[-6:]
+
+    def _get_raw_crash_path(self, crash_id):
+        """Returns path for where the raw crash should go"""
+        return os.path.join(
+            self.root,
+            self._get_crash_date(crash_id),
+            'raw_crash',
+            crash_id + '.json'
+        )
+
+    def _get_dump_names_path(self, crash_id):
+        return os.path.join(
+            self.root,
+            self._get_crash_date(crash_id),
+            'dump_names',
+            crash_id + '.json'
+        )
+
+    def _get_dump_name_path(self, crash_id, dump_name):
+        return os.path.join(
+            self.root,
+            self._get_crash_date(crash_id),
+            dump_name,
+            crash_id
+        )
+
+    def save_raw_crash(self, raw_crash, dumps, crash_id):
+        """Saves the raw crash and related dumps
+
+        FIXME(willkg): How should this method handle exceptions?
+
+        :arg raw_crash: dict The raw crash as a dict.
+        :arg dumps: Map of dump name (e.g. ``upload_file_minidump``) to dump contents.
+        :arg crash_id: The crash id as a string.
+
+        """
+        print((raw_crash, dumps.keys(), crash_id))
+
+        files = {}
+
+        # Add raw_crash to the list of files to save.
+        files[self._get_raw_crash_path(crash_id)] = json_ordered_dumps(raw_crash).encode('utf-8')
+
+        # Add dump_names to the list of files to save. We always generate this
+        # even if there are no dumps.
+        files[self._get_dump_names_path(crash_id)] = json_ordered_dumps(list(sorted(dumps.keys()))).encode('utf-8')
+
+        # Add the dump files if there are any.
+        for dump_name, dump in dumps.items():
+            files[self._get_dump_name_path(crash_id, dump_name)] = dump
+
+        # Save all the files.
+        for fn, contents in files.items():
+            logger.debug('Saving file %r', fn)
+            path = os.path.dirname(fn)
+
+            # FIXME(willkg): What happens if there is something here already and
+            # it's not a directory?
+            if not os.path.exists(path):
+                os.makedirs(path)
+
+            # FIXME(willkg): This will stomp on existing crashes. Is that ok?
+            # Should we detect and do something different somehow?
+            with open(fn, 'wb') as fp:
+                fp.write(contents)

--- a/antenna/util.py
+++ b/antenna/util.py
@@ -3,11 +3,35 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 
+import json
+
+
 def de_null(value):
-    """Remove nulls from bytes and str values"""
+    """Remove nulls from bytes and str values
+
+    :arg value: The str or bytes to remove nulls from
+
+    :returns: str or bytes without nulls
+
+    """
     if isinstance(value, bytes) and b'\0' in value:
         # FIXME: might need to use translate(None, b'\0')
         return value.replace(b'\0', b'')
     if isinstance(value, str) and '\0' in value:
         return value.replace('\0', '')
     return value
+
+
+def json_ordered_dumps(data):
+    """Dumps Python data into JSON with sorted_keys
+
+    This returns a str. If you need bytes, do this::
+
+         json_ordered_dumps(data).encode('utf-8')
+
+    :arg data: The data to convert to JSON
+
+    :returns: string
+
+    """
+    return json.dumps(data, sort_keys=True)

--- a/docs/spec_v1.rst
+++ b/docs/spec_v1.rst
@@ -116,3 +116,56 @@ My current thinking is that we've got the following rough options:
 Given that, I'm inclined to go the Python route. At some point it may prove to
 be an unenthusing decision, but I don't think the risks are high enough that
 it'll ever be a **wrong** decision.
+
+
+Crash reports
+=============
+
+Crash reports come in via ``/submit`` as an HTTP POST.
+
+They have a ``multipart/form-data`` content-type.
+
+The payload (HTTP POST request body) may or may not be compressed. If it's
+compressed, then we need to uncompress it.
+
+The payload has a bunch of key/val pairs and also one or more binary parts.
+
+Binary parts have XXX filename and XXX content-type.
+
+The crash_id and dump names are essentially user-provided data and affect things
+like filenames and s3 pseudo-filenames. They should get sanitized.
+
+Possible binary part names:
+
+* ``memory_report``
+* ``upload_file_minidump``
+* ``upload_file_minidump_browser``
+* ``upload_file_minidump_content``
+* ``upload_file_minidump_flash1``
+* ``upload_file_minidump_flash2``
+
+Some of these come from ``.dmp`` files on the client computer.
+
+Thus an HTTP POST something like this::
+
+    FIXME
+
+
+Which gets converted to a ``raw_crash`` like this::
+
+    FIXME
+
+
+Which ends up in S3 like this::
+
+    /v2/raw_crash/000/20160920/60db7156-3553-27e3-38900067-31a261ed
+
+        Raw crash in serialized in JSON.
+
+    /v1/dump_names/60db7156-3553-27e3-38900067-31a261ed
+
+        Map of dump_name to file name serialized in JSON.
+
+    /v1/upload_file_minidump_browser/60db7156-3553-27e3-38900067-31a261ed
+
+        Raw dumps.

--- a/tests/test_crashstorage.py
+++ b/tests/test_crashstorage.py
@@ -13,10 +13,6 @@ MOCK_TIME = time.mktime(MOCK_DATETIME.timetuple())
 
 
 class TestCrashStorage:
-    config_vars = {
-        # FIXME: Set crash storage to noop
-    }
-
     @mock.patch('antenna.app.time')
     @mock.patch('antenna.app.utc_now')
     def test_flow(self, mock_utc_now, mock_time, client, payload_generator):
@@ -57,7 +53,8 @@ class TestCrashStorage:
                 'submitted_timestamp': '2011-09-06T00:00:00+00:00',
                 'timestamp': 1315267200.0,
                 'type_tag': 'bp',
-                'uuid': 'de1bb258-cbbf-4589-a673-34f802160918'}
+                'uuid': 'de1bb258-cbbf-4589-a673-34f802160918'
+            }
         )
         assert (
             crash['dumps'] ==


### PR DESCRIPTION
This implements a rudimentary file system crash store that mimics the
"directory structure" of what we're going to do on S3, but does it on
a local file system.

There are a bunch of FIXMEs that should get thought through at some
point, but since I'm only using this crash store for
development/testing purposes, I'm going to leave those be for now.