### PR TITLE
Cleanup test Client

### DIFF
--- a/tests/unittest/test_app.py
+++ b/tests/unittest/test_app.py
@@ -5,8 +5,6 @@
 import gzip
 import io
 
-from everett.manager import config_override
-
 from antenna.app import BreakpadSubmitterResource
 
 
@@ -14,26 +12,26 @@ class TestHealthVersionResource:
     def test_no_version(self, client, tmpdir):
         # Set basedir here to tmpdir which we *know* doesn't have a
         # version.json in it.
-        with config_override(BASEDIR=str(tmpdir)):
-            # Rebuild the app to pick up the overridden configuration.
-            client.rebuild_app()
+        client.rebuild_app({
+            'BASEDIR': str(tmpdir)
+        })
 
-            result = client.get('/__version__')
-            assert result.content == b'{}'
+        result = client.get('/__version__')
+        assert result.content == b'{}'
 
     def test_version(self, client, tmpdir):
-        with config_override(BASEDIR=str(tmpdir)):
-            # Rebuild the app to pick up the overridden configuration.
-            client.rebuild_app()
+        client.rebuild_app({
+            'BASEDIR': str(tmpdir)
+        })
 
-            # NOTE(willkg): The actual version.json has other things in it,
-            # but our endpoint just spits out the file verbatim, so we
-            # can test with whatever.
-            version_path = tmpdir.join('/version.json')
-            version_path.write('{"commit": "ou812"}')
+        # NOTE(willkg): The actual version.json has other things in it,
+        # but our endpoint just spits out the file verbatim, so we
+        # can test with whatever.
+        version_path = tmpdir.join('/version.json')
+        version_path.write('{"commit": "ou812"}')
 
-            result = client.get('/__version__')
-            assert result.content == b'{"commit": "ou812"}'
+        result = client.get('/__version__')
+        assert result.content == b'{"commit": "ou812"}'
 
 
 class TestBreakpadSubmitterResource:

--- a/tests/unittest/test_fs_crashstorage.py
+++ b/tests/unittest/test_fs_crashstorage.py
@@ -6,7 +6,6 @@ import datetime
 import os
 import time
 
-from everett.manager import config_override
 import mock
 
 
@@ -33,21 +32,20 @@ class TestFSCrashStorage:
 
         boundary, data = payload_generator('socorrofake1_withuuid.raw')
 
-        with config_override(
-                BASEDIR=str(tmpdir),
-                FS_ROOT=str(tmpdir.join('antenna_crashes')),
-                CRASHSTORAGE_CLASS='antenna.external.fs.crashstorage.FSCrashStorage'
-        ):
-            # Rebuild the app to pick up the overridden configuration.
-            client.rebuild_app()
+        # Rebuild the app the test client is using with relevant configuration.
+        client.rebuild_app({
+            'BASEDIR': str(tmpdir),
+            'FS_ROOT': str(tmpdir.join('antenna_crashes')),
+            'CRASHSTORAGE_CLASS': 'antenna.external.fs.crashstorage.FSCrashStorage'
+        })
 
-            result = client.post(
-                '/submit',
-                headers={
-                    'Content-Type': 'multipart/form-data; boundary=' + boundary,
-                },
-                body=data
-            )
+        result = client.post(
+            '/submit',
+            headers={
+                'Content-Type': 'multipart/form-data; boundary=' + boundary,
+            },
+            body=data
+        )
 
         assert result.status_code == 200
 


### PR DESCRIPTION
This fixes some issues with the test Client where the client has a copy
of the app, but we need to rebuild the app with a certain configuration
for some tests and it was awkward to get the right order of operations.

Now you can just call .rebuild_app() and give it a new configuration
and you're all set.