### PR TITLE
Fix docs creation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,8 @@ FROM python:3.5.2-slim
 WORKDIR /app/
 RUN groupadd --gid 1001 app && useradd -g app --uid 1001 --shell /usr/sbin/nologin app
 
-RUN apt-get update && apt-get install -y \
-    gcc apt-transport-https
+RUN apt-get update && \
+    apt-get install -y gcc apt-transport-https
 
 COPY ./requirements.txt /app/requirements.txt
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,10 @@
+FROM local/antenna_deploy_base
+
+# Switch to root to install stuff
+USER root
+
+# Install build essentials which includes make
+RUN apt-get install -y build-essential
+
+# Switch back to app user
+USER app

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 DCFILE ?= "docker-compose.yml"
-DC := $(shell which docker-compose) -f ${DCFILE}
+DC := $(shell which docker-compose)
 
 default:
 	@echo "You need to specify a subcommand."
@@ -20,7 +20,9 @@ help:
 	make build
 
 build:
-	${DC} build
+	${DC} build deploy-base
+	${DC} build dev-base
+	${DC} build web
 	touch .docker-build
 
 run: .docker-build
@@ -58,6 +60,8 @@ test-coverage:
 
 docs:
 	${DC} run web $(MAKE) -C docs/ clean
+	-mkdir -p docs/_build/
+	chmod -R 777 docs/_build/
 	${DC} run web $(MAKE) -C docs/ html
 	${DC} run web find docs/_build/ -type d -exec 'chmod' '777' '{}' ';'
 	${DC} run web find docs/_build/ -type f -exec 'chmod' '666' '{}' ';'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,10 +3,28 @@
 # Note: Requires docker 1.10.0+ and docker-compose 1.6.0+.
 version: "2"
 services:
-  web:
+  # This builds an image of the deploy base. Then we extend that with
+  # dev-related things to do our dev-y stuff.
+  deploy-base:
     build:
       context: .
       dockerfile: Dockerfile
+    image: local/antenna_deploy_base
+
+  # This builds an image that extends Dockerfile with dev-related things.
+  dev-base:
+    build:
+      context: .
+      dockerfile: Dockerfile.dev
+    image: local/antenna_dev
+
+  # ------------------------------------------------------------------
+  # After this point is dev-related services.
+  # ------------------------------------------------------------------
+
+  # This is the base web-service.
+  web:
+    image: local/antenna_dev
     volumes:
       - .:/app
     ports:


### PR DESCRIPTION
This creates a bunch of docker stuff so that we can have a separate
docker image for doing development-specific things without having some
of the tools we need to install available in the deploy image.

The new local/antenna_dev image has make which we need to build the
docs.