### PR TITLE
Fix error handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ build:
 	touch .docker-build
 
 run: .docker-build
-	${DC} up
+	${DC} up web
 
 clean:
 	# python related things


### PR DESCRIPTION
Previously, unhandled errors would propagate all the way up and Falcon
would just return an HTTP 500 to the client, but wouldn't log anything
which ... is unhelpful.

This replaces that with a handler that logs the exception and then
returns a HTTP 500 to the client.