### PR TITLE
Move post handling to the eventpool

### DIFF
--- a/tests/unittest/conftest.py
+++ b/tests/unittest/conftest.py
@@ -120,6 +120,40 @@ class Client:
             new_config = {}
         self.app = build_app(new_config)
 
+    def get_resource_by_url(self, url):
+        """Gets a resource instance given a url it maps to
+
+        For example::
+
+            client.get_resource_by_url('/submit')
+
+        """
+        # NOTE(willkg): We do this goofy thing to get the resources from the
+        # app using internal Falcon API things. It's entirely possible that
+        # this will break when we upgrade Falcon, but there's no other way to
+        # get this without adding more layers of things and possibly breaking the
+        # time/space continuum.
+        return self.app._router.find(url)[0]
+
+    def join_app(self):
+        """This goes through and calls join on all gevent pools in the app
+
+        Call this after doing a ``.get()`` or ``.post()`` to force all post
+        processing to occur before this returns.
+
+        For example::
+
+            resp = client.get(...)
+            client.join_app()
+
+            assert resp.status_code == 200
+
+        """
+        # FIXME(willkg): This is hard-coded for now. We can fix that later if
+        # we add other pools to the system.
+        bsr = self.get_resource_by_url('/submit')
+        bsr.join_pool()
+
     def get(self, path, headers=None, **kwargs):
         return self._request(
             'GET', path=path, headers=headers, **kwargs

--- a/tests/unittest/test_crashstorage.py
+++ b/tests/unittest/test_crashstorage.py
@@ -25,14 +25,10 @@ class TestCrashStorage:
             headers=headers,
             body=data
         )
+        client.join_app()
         assert result.status_code == 200
 
-        # NOTE(willkg): We do this goofy thing to get the
-        # BreakpadSubmitterResource using internal Falcon API things. It's
-        # entirely possible that this will break when we upgrade Falcon, but
-        # there's no other way to get this without doing other crazier things
-        # and possibly breaking the time/space continuum.
-        bsr, method_map, params = client.app._router.find('/submit')
+        bsr = client.get_resource_by_url('/submit')
 
         # Now we've got the BreakpadSubmitterResource, so we can pull out the
         # crashstorage, verify there's only one crash in it and then verify the

--- a/tests/unittest/test_fs_crashstorage.py
+++ b/tests/unittest/test_fs_crashstorage.py
@@ -44,6 +44,7 @@ class TestFSCrashStorage:
             headers=headers,
             body=data
         )
+        client.join_app()
 
         assert result.status_code == 200
 
@@ -116,6 +117,7 @@ class TestFSCrashStorage:
             headers=headers,
             body=data
         )
+        client.join_app()
 
         assert result.status_code == 200
 


### PR DESCRIPTION
Prior to this change, we were saving the crash during the HTTP
request/response cycle.

This fixes it so that we spawn an eventlet to handle storing the crash
and whatever else needs to happen so that we can return a crash id to
the breakpad client and end the HTTP conversation as soon as possible.

We put all the eventlets in a pipeline_pool so that we can count them
and keep track of them.

This also moves some yucky code out of the tests and into the test
client to improve the readability of our test code.