### PR TITLE
Fix problems when running a single test

### DIFF
--- a/antenna/app.py
+++ b/antenna/app.py
@@ -181,7 +181,7 @@ class BreakpadSubmitterResource(RequiredConfigMixin):
             # the payload size by decompressing it. We save the original value
             # in case we need to debug something later on.
             req.env['ORIG_CONTENT_LENGTH'] = content_length
-            req.env['CONTENT_LENGTH'] = len(data)
+            req.env['CONTENT_LENGTH'] = str(len(data))
 
             data = io.BytesIO(data)
         else:


### PR DESCRIPTION
Falcon has a global variable that it flips to False if it encounters a
request stream that it doesn't need to wrap. We have a test that
causes that to happen. So any test that runs before that test has run
and flipped the global to False fails.

For some reason that I didn't track down, the
falcon.request_helper.Body class doesn't work with cgi.FieldStorage
causing us to get empty crash reports and fail tests.

Instead of dealing with that, this explicitly flips the global to
False and adds a big comment about the situation. The thinking being
that this is our test suite, we don't need to test their wrapping and
we're running under gunicorn which doesn't trigger the wrapping.