### PR TITLE
Fix NoneType issues

### DIFF
--- a/antenna/app.py
+++ b/antenna/app.py
@@ -401,7 +401,7 @@ def get_app(config=None):
     if config is None:
         config = ConfigManager([
             # Pull configuration from env file specified as ANTENNA_ENV
-            ConfigEnvFileEnv(os.environ.get('ANTENNA_ENV')),
+            ConfigEnvFileEnv([os.environ.get('ANTENNA_ENV')]),
             # Pull configuration from environment variables
             ConfigOSEnv()
         ])

--- a/bin/create_fakes3_bucket.py
+++ b/bin/create_fakes3_bucket.py
@@ -46,7 +46,7 @@ def main(args):
     # Build configuration object just like we do in Antenna.
     config = ConfigManager([
         # Pull configuration from env file specified as ANTENNA_ENV
-        ConfigEnvFileEnv(os.environ.get('ANTENNA_ENV')),
+        ConfigEnvFileEnv([os.environ.get('ANTENNA_ENV')]),
         # Pull configuration from environment variables
         ConfigOSEnv()
     ])


### PR DESCRIPTION
If ANTENNA_ENV wasn't defined, then Antenna would raise an exception
on startup due to a bug in Everett.

This changes the code so it doesn't tickle the bug.