### PR TITLE
Fix error handling

### DIFF
--- a/tests/unittest/test_app.py
+++ b/tests/unittest/test_app.py
@@ -9,6 +9,12 @@ from antenna.mini_poster import multipart_encode
 from antenna.util import compress
 
 
+class Test404:
+    def test_404(self, client):
+        result = client.get('/foo')
+        assert result.status_code == 404
+
+
 class TestHomePageResource:
     def test_home_page(self, client):
         result = client.get('/')


### PR DESCRIPTION
Previously, all "errors" were handled and then returned HTTP 500, but
that included things that should have been 404, 403, etc.

This fixes the error handling to do the right thing. All we wanted to do
that was different than what Falcon currently does is log unhandled
exceptions.