### PR TITLE
Fix logging and logging mock

### DIFF
--- a/antenna/loggingmock.py
+++ b/antenna/loggingmock.py
@@ -24,6 +24,9 @@ class LoggingMock(logging.Handler):
         self.records.append(record)
 
     def install_handler(self):
+        if self.names is None:
+            self.names = [None]
+
         for name in self.names:
             logger = logging.getLogger(name)
             logger.addHandler(self)
@@ -34,6 +37,7 @@ class LoggingMock(logging.Handler):
             logger.removeHandler(self)
 
     def __enter__(self):
+        self.records = []
         self.install_handler()
         return self
 
@@ -68,6 +72,14 @@ class LoggingMock(logging.Handler):
 
     def get_records(self):
         return self.records
+
+    def print_records(self):
+        records = self.get_records()
+        if records:
+            for record in records:
+                print((record.name, record.levelname, record.message))
+        else:
+            print('NO RECORDS')
 
     def clear(self):
         self.records = []

--- a/prod.env
+++ b/prod.env
@@ -2,6 +2,9 @@
 #
 # See https://antenna.readthedocs.io/ for documentation.
 
+# DEBUG is helpful for development, but otherwise we'd use INFO
+LOGGING_LEVEL=DEBUG
+
 # BreakdpadSubmitterResource settings
 CRASHSTORAGE_CLASS=antenna.external.s3.crashstorage.S3CrashStorage
 

--- a/tests/unittest/test_s3_crashstorage.py
+++ b/tests/unittest/test_s3_crashstorage.py
@@ -200,24 +200,25 @@ class TestS3MockLogging:
             'CRASHSTORAGE_BUCKET_NAME': 'fakebucket',
         })
 
-        result = client.post(
-            '/submit',
-            headers=headers,
-            body=data
-        )
-        client.join_app()
+        with loggingmock(['antenna']) as lm:
+            result = client.post(
+                '/submit',
+                headers=headers,
+                body=data
+            )
+            client.join_app()
 
-        # Verify the collector returns a 200 status code and the crash id
-        # we fed it.
-        assert result.status_code == 200
-        assert result.content == b'CrashID=bp-de1bb258-cbbf-4589-a673-34f802160918\n'
+            # Verify the collector returns a 200 status code and the crash id
+            # we fed it.
+            assert result.status_code == 200
+            assert result.content == b'CrashID=bp-de1bb258-cbbf-4589-a673-34f802160918\n'
 
-        # Verify the retry decorator logged something
-        assert loggingmock.has_record(
-            name='antenna.external.s3.connection',
-            levelname='ERROR',
-            msg_contains='retry attempt 0'
-        )
+            # Verify the retry decorator logged something
+            assert lm.has_record(
+                name='antenna.external.s3.connection',
+                levelname='ERROR',
+                msg_contains='retry attempt 0'
+            )
 
     # FIXME(willkg): Add test for bad region
     # FIXME(willkg): Add test for invalid credentials


### PR DESCRIPTION
This adds a configurable logging level to setup_logging and the app
configuration.

This also fixes the logging mock and py.test fixture to work better
especially in regards to how setup_logging() only happens once.