### PR TITLE
Add a throttler

### DIFF
--- a/antenna/throttler.py
+++ b/antenna/throttler.py
@@ -2,16 +2,197 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+import importlib
+import logging
+import random
+import re
+
+from everett.component import ConfigOptions, RequiredConfigMixin
+
+
+logger = logging.getLogger(__name__)
+
+
 ACCEPT = 0   # save and process
 DEFER = 1    # save but don't process
-DISCARD = 2  # tell client to go away and not come back
-IGNORE = 3   # ignore submission entirely
+REJECT = 2   # tell client to go away and not come back
 
 
-class Throttler:
+def parse_attribute(val):
+    module, attribute_name = val.rsplit('.', 1)
+    module = importlib.import_module(module)
+    try:
+        return getattr(module, attribute_name)
+    except AttributeError:
+        raise ValueError(
+            '%s is not a valid attribute of %s' %
+            (attribute_name, module)
+        )
+
+
+class Throttler(RequiredConfigMixin):
+    """Accepts/rejects incoming crashes based on specified rule set
+
+    The throttler can throttle incoming crashes using the content of the crash.
+    To throttle, you set up a rule set which is a list of ``Rule`` instances.
+    That goes in a Python module which is loaded at run time.
+
+    If you don't want to throttle anything, use this::
+
+        THROTTLE_RULES=antenna.throttler.accept_all
+
+
+    To set up a rule set, put it in a ``myruleset.py`` Python file like this::
+
+        from antenna.throttler import Rule
+
+        rules = [
+            Rule('ProductName', 'Firefox', 100),
+            # ...
+        ]
+
+    then set ``THROTTLE_RULES`` to the path for that. For example, depending
+    on the current working directory and ``PYTHONPATH``, the above could be::
+
+        THROTTLE_RULES=myruleset.rules
+
+
+    FIXME(willkg): Flesh this out.
+
+    """
+    required_config = ConfigOptions()
+    required_config.add_option(
+        'throttle_rules',
+        default='antenna.throttler.mozilla_rules',
+        doc='Python dotted path to ruleset',
+        parser=parse_attribute
+    )
+
     def __init__(self, config):
-        pass
+        self.config = config.with_options(self)
+        self.rule_set = self.config('throttle_rules')
 
-    def throttle(self, raw_crash):
-        # FIXME: Implement
-        return ACCEPT, 100
+    def throttle(self, crash_id, raw_crash):
+        """Go through rule set to ACCEPT, REJECT or DEFER"""
+        logger.info('INFO!')
+        for rule in self.rule_set:
+            match = rule.match(raw_crash)
+
+            if match:
+                logger.debug('%s: matched by %s', crash_id, rule.rule_name)
+
+                if rule.percentage is None:
+                    logger.debug('%s: percentage is None: rejecting', crash_id)
+                    return REJECT, None
+
+                random_number = random.random() * 100.0
+                response = DEFER if random_number > rule.percentage else ACCEPT
+                return response, rule.percentage
+
+        logger.debug('%s: out of rules: rejected', crash_id)
+
+        # None of the rules matched, so we reject
+        return REJECT, 0
+
+
+REGEXP_TYPE = type(re.compile(''))
+
+
+class Rule:
+    """Defines a single rule"""
+    def __init__(self, rule_name, key, condition, percentage):
+        """Creates a Rule
+
+        :arg str rule_name: The friendly name for the rule. We use this for
+            logging and statsd.
+
+        :arg str key: The key in the raw crash to look at. ``*`` to look at the
+            whole crash.
+
+        :arg varies condition: The condition that determines whether this rule
+            matches.
+
+            This can be a function that takes ``raw_crash[key]`` as a value
+            or if the key is ``*``, the entire crash.
+
+            This can be a boolean which will always return that value for all
+            crashes.
+
+            This can be any other kind of value which will be compared for equality
+            with ``raw_crash[key]``.
+
+        :arg int percentage: The percentage of crashes that match the condition
+            to accept and process.
+
+        """
+        self.rule_name = rule_name
+        self.key = key
+        self.condition = self._to_handler(condition)
+        self.percentage = percentage
+
+    def __repr__(self):
+        return self.rule_name
+
+    def _to_handler(self, condition):
+        # If it's a callable, then it can be a handler
+        if callable(condition):
+            return condition
+
+        # If it's a regexp, then we return a function that does a regexp
+        # search on the value
+        if isinstance(condition, REGEXP_TYPE):
+            def handler(val):
+                return bool(condition.search(val))
+            return handler
+
+        # If we're at this point, then we assume it's a value for
+        # an equality test
+        return lambda val: val == condition
+
+    def match(self, crash):
+        if self.key == '*':
+            return self.condition(crash)
+
+        if self.key in crash:
+            return self.condition(crash[self.key])
+
+        return False
+
+
+def match_all(crash):
+    return True
+
+
+accept_all = [
+    # Accept everything
+    Rule('accept_everything', '*', match_all, 100)
+]
+
+
+mozilla_rules = [
+    # Drop browser side of all multi-submission hang crashes
+    Rule('has_hangid_and_browser', '*', lambda d: 'HangID' in d and d.get('ProcessType', 'browser') == 'browser', None),
+
+    # 100% of crashes that have a comment
+    Rule('has_comments', 'Comments', match_all, 100),
+
+    # 100% of all ReleaseChannel=aurora, beta, esr channels
+    Rule('is_alpha_beta_esr', 'ReleaseChannel', lambda x: x in ('aurora', 'beta', 'esr'), 100),
+
+    # 100% of all ReleaseChannel=nightly
+    Rule('is_nightly', 'ReleaseChannel', lambda x: x.startswith('nightly'), 100),
+
+    # 10% of ProductName=Firefox
+    Rule('is_firefox_desktop', 'ProductName', 'Firefox', 10),
+
+    # 100% of PrductName=Fennec
+    Rule('is_fennec', 'ProductName', 'Fennec', 100),
+
+    # 100% of all Version=alpha, beta or special
+    Rule('is_version_alpha_beta_special', 'Version', re.compile(r'\..*?[a-zA-Z]+'), 100),
+
+    # 100% of ProductName=Thunderbird & SeaMonkey
+    Rule('is_thunderbird_seamonkey', 'ProductName', lambda x: x[0] in 'TSC', 100),
+
+    # Reject everything else
+]

--- a/tests/unittest/conftest.py
+++ b/tests/unittest/conftest.py
@@ -5,6 +5,7 @@
 import contextlib
 
 import sys
+from unittest import mock
 
 from everett.manager import ConfigManager
 import falcon
@@ -22,7 +23,7 @@ import wsgiref.validate
 sys.path.insert(0, str(local(__file__).dirpath().dirpath().dirpath()))
 
 
-from antenna.app import get_app  # noqa
+from antenna.app import get_app, setup_logging  # noqa
 from antenna.loggingmock import LoggingMock  # noqa
 from antenna.s3mock import S3Mock  # noqa
 
@@ -211,9 +212,10 @@ def loggingmock():
                 )
 
 
-    You can also specify logger names to mock::
+    You can specify names, too::
 
-            with loggingmock(['antenna']) as lm:
+        def test_something(loggingmock):
+            with loggingmock(['antenna', 'botocore']) as lm:
                 # do stuff
                 assert lm.has_record(
                     name='foo.bar',
@@ -227,3 +229,23 @@ def loggingmock():
         with LoggingMock(names=names) as loggingmock:
             yield loggingmock
     return _loggingmock
+
+
+@pytest.fixture
+def randommock():
+    """Returns a contextmanager that mocks random.random() at a specific value
+
+    Usage::
+
+        def test_something(randommock):
+            with randommock(0.55):
+                # test stuff...
+
+    """
+    @contextlib.contextmanager
+    def _randommock(value):
+        with mock.patch('random.random') as mock_random:
+            mock_random.return_value = value
+            yield
+
+    return _randommock

--- a/tests/unittest/conftest.py
+++ b/tests/unittest/conftest.py
@@ -23,7 +23,7 @@ import wsgiref.validate
 sys.path.insert(0, str(local(__file__).dirpath().dirpath().dirpath()))
 
 
-from antenna.app import get_app, setup_logging  # noqa
+from antenna.app import get_app  # noqa
 from antenna.loggingmock import LoggingMock  # noqa
 from antenna.s3mock import S3Mock  # noqa
 

--- a/tests/unittest/test_crashstorage.py
+++ b/tests/unittest/test_crashstorage.py
@@ -13,6 +13,10 @@ class TestCrashStorage:
     @freeze_time('2011-09-06 00:00:00', tz_offset=0)
     def test_flow(self, client):
         """Verify posting a crash gets to crash storage in the right shape"""
+        client.rebuild_app({
+            'THROTTLE_RULES': 'antenna.throttler.accept_all'
+        })
+
         data, headers = multipart_encode({
             'uuid': 'de1bb258-cbbf-4589-a673-34f802160918',
             'ProductName': 'Test',
@@ -42,6 +46,8 @@ class TestCrashStorage:
                 'ProductName': 'Test',
                 'Version': '1.0',
                 'dump_checksums': {'upload_file_minidump': 'e19d5cd5af0378da05f63f891c7467af'},
+                'legacy_processing': 0,
+                'percentage': 100,
                 'submitted_timestamp': '2011-09-06T00:00:00+00:00',
                 'timestamp': 1315267200.0,
                 'type_tag': 'bp',

--- a/tests/unittest/test_fs_crashstorage.py
+++ b/tests/unittest/test_fs_crashstorage.py
@@ -35,6 +35,7 @@ class TestFSCrashStorage:
         # Rebuild the app the test client is using with relevant configuration.
         client.rebuild_app({
             'BASEDIR': str(tmpdir),
+            'THROTTLE_RULES': 'antenna.throttler.accept_all',
             'CRASHSTORAGE_CLASS': 'antenna.external.fs.crashstorage.FSCrashStorage',
             'CRASHSTORAGE_FS_ROOT': str(tmpdir.join('antenna_crashes')),
         })
@@ -76,6 +77,8 @@ class TestFSCrashStorage:
                 b'{"ProductName": "Test", ' +
                 b'"Version": "1.0", ' +
                 b'"dump_checksums": {"upload_file_minidump": "e19d5cd5af0378da05f63f891c7467af"}, ' +
+                b'"legacy_processing": 0, ' +
+                b'"percentage": 100, ' +
                 b'"submitted_timestamp": "2011-09-06T00:00:00+00:00", ' +
                 b'"timestamp": 1315267200.0, ' +
                 b'"type_tag": "bp", ' +
@@ -108,6 +111,7 @@ class TestFSCrashStorage:
         # Rebuild the app the test client is using with relevant configuration.
         client.rebuild_app({
             'BASEDIR': str(tmpdir),
+            'THROTTLE_RULES': 'antenna.throttler.accept_all',
             'CRASHSTORAGE_CLASS': 'antenna.external.fs.crashstorage.FSCrashStorage',
             'CRASHSTORAGE_FS_ROOT': str(tmpdir.join('antenna_crashes')),
         })
@@ -136,6 +140,8 @@ class TestFSCrashStorage:
                 'ProductName': 'Test',
                 'Version': '1.0',
                 'dump_checksums': {'upload_file_minidump': 'e19d5cd5af0378da05f63f891c7467af'},
+                'legacy_processing': 0,
+                'percentage': 100,
                 'submitted_timestamp': '2011-09-06T00:00:00+00:00',
                 'timestamp': 1315267200.0,
                 'type_tag': 'bp',

--- a/tests/unittest/test_throttler.py
+++ b/tests/unittest/test_throttler.py
@@ -75,12 +75,7 @@ class Testaccept_all:
             'THROTTLE_RULES': 'antenna.throttler.accept_all'
         }))
 
-        answer, percent = throttler.throttle(
-            '11234',
-            {'ProductName': 'Test'}
-        )
-
-        assert answer is ACCEPT
+        assert throttler.throttle('11234', {'ProductName': 'Test'}) == (ACCEPT, 100)
 
 
 class Testmozilla_rules:
@@ -94,11 +89,9 @@ class Testmozilla_rules:
 
         with loggingmock(['antenna']) as lm:
             throttler = Throttler(ConfigManager.from_dict({}))
-            answer, percent = throttler.throttle('11234', raw_crash)
 
             # Reject anything with a HangId and ProcessType = 'browser'
-            assert answer is REJECT
-            assert percent is None
+            assert throttler.throttle('11234', raw_crash) == (REJECT, None)
 
             assert lm.has_record(
                 name='antenna.throttler',
@@ -114,10 +107,8 @@ class Testmozilla_rules:
 
         with loggingmock(['antenna']) as lm:
             throttler = Throttler(ConfigManager.from_dict({}))
-            answer, percent = throttler.throttle('11234', raw_crash)
 
-            assert answer is ACCEPT
-            assert percent is 100
+            assert throttler.throttle('11234', raw_crash) == (ACCEPT, 100)
 
             assert lm.has_record(
                 name='antenna.throttler',
@@ -138,10 +129,8 @@ class Testmozilla_rules:
 
         with loggingmock(['antenna']) as lm:
             throttler = Throttler(ConfigManager.from_dict({}))
-            answer, percent = throttler.throttle('11234', raw_crash)
 
-            assert answer is ACCEPT
-            assert percent is 100
+            assert throttler.throttle('11234', raw_crash) == (ACCEPT, 100)
 
             assert lm.has_record(
                 name='antenna.throttler',
@@ -160,10 +149,8 @@ class Testmozilla_rules:
         }
         with loggingmock(['antenna']) as lm:
             throttler = Throttler(ConfigManager.from_dict({}))
-            answer, percent = throttler.throttle('11234', raw_crash)
 
-            assert answer is ACCEPT
-            assert percent is 100
+            assert throttler.throttle('11234', raw_crash) == (ACCEPT, 100)
 
             assert lm.has_record(
                 name='antenna.throttler',
@@ -178,10 +165,8 @@ class Testmozilla_rules:
             }
             with loggingmock(['antenna']) as lm:
                 throttler = Throttler(ConfigManager.from_dict({}))
-                answer, percent = throttler.throttle('11234', raw_crash)
 
-                assert answer is ACCEPT
-                assert percent is 10
+                assert throttler.throttle('11234', raw_crash) == (ACCEPT, 10)
 
                 assert lm.has_record(
                     name='antenna.throttler',
@@ -195,10 +180,8 @@ class Testmozilla_rules:
             }
             with loggingmock(['antenna']) as lm:
                 throttler = Throttler(ConfigManager.from_dict({}))
-                answer, percent = throttler.throttle('11234', raw_crash)
 
-                assert answer is DEFER
-                assert percent is 10
+                assert throttler.throttle('11234', raw_crash) == (DEFER, 10)
 
                 assert lm.has_record(
                     name='antenna.throttler',
@@ -212,10 +195,8 @@ class Testmozilla_rules:
         }
         with loggingmock(['antenna']) as lm:
             throttler = Throttler(ConfigManager.from_dict({}))
-            answer, percent = throttler.throttle('11234', raw_crash)
 
-            assert answer is ACCEPT
-            assert percent is 100
+            assert throttler.throttle('11234', raw_crash) == (ACCEPT, 100)
 
             assert lm.has_record(
                 name='antenna.throttler',
@@ -236,10 +217,8 @@ class Testmozilla_rules:
         }
         with loggingmock(['antenna']) as lm:
             throttler = Throttler(ConfigManager.from_dict({}))
-            answer, percent = throttler.throttle('11234', raw_crash)
 
-            assert answer is ACCEPT
-            assert percent is 100
+            assert throttler.throttle('11234', raw_crash) == (ACCEPT, 100)
 
             assert lm.has_record(
                 name='antenna.throttler',
@@ -257,10 +236,8 @@ class Testmozilla_rules:
         }
         with loggingmock(['antenna']) as lm:
             throttler = Throttler(ConfigManager.from_dict({}))
-            answer, percent = throttler.throttle('11234', raw_crash)
 
-            assert answer is ACCEPT
-            assert percent is 100
+            assert throttler.throttle('11234', raw_crash) == (ACCEPT, 100)
 
             assert lm.has_record(
                 name='antenna.throttler',

--- a/tests/unittest/test_throttler.py
+++ b/tests/unittest/test_throttler.py
@@ -1,0 +1,117 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import re
+
+from everett.manager import ConfigManager
+
+from antenna.throttler import Rule, Throttler, ACCEPT, DEFER, REJECT
+
+
+class TestRule:
+    def test_star(self):
+        def is_crash(thing):
+            return isinstance(thing, dict)
+
+        # Asserts that the is_crash condition function got a crash as an
+        # argument.
+        rule = Rule('test', '*', is_crash, 100)
+        assert rule.match({'ProductName': 'test'}) is True
+
+        # Asserts that the is_crash condition function did not get a crash as
+        # an argument.
+        rule = Rule('test', 'ProductName', is_crash, 100)
+        assert rule.match({'ProductName': 'Test'}) is False
+
+    def test_condition_function(self):
+        rule = Rule('test', '*', lambda x: True, 100)
+        assert rule.match({'ProductName': 'test'}) is True
+
+        rule = Rule('test', '*', lambda x: False, 100)
+        assert rule.match({'ProductName': 'test'}) is False
+
+    def test_condition_regexp(self):
+        rule = Rule('test', 'ProductName', re.compile('^test'), 100)
+        assert rule.match({'ProductName': 'testabc'}) is True
+        assert rule.match({'ProductName': 'abc'}) is False
+
+    def test_condition_value(self):
+        rule = Rule('test', 'ProductName', 'test', 100)
+        assert rule.match({'ProductName': 'test'}) is True
+        assert rule.match({'ProductName': 'testabc'}) is False
+
+        rule = Rule('test', 'Version', 1.0, 100)
+        assert rule.match({'Version': 1.0}) is True
+        assert rule.match({'Version': 2.0}) is False
+
+        assert rule.match({'ProductName': 'testabc'}) is False
+
+    def test_percentage(self, randommock):
+        throttler = Throttler(ConfigManager.from_dict({}))
+
+        # Overrwrite the rule set for something we need
+        throttler.rule_set = [
+            Rule('test', 'ProductName', 'test', 50)
+        ]
+
+        with randommock(0.45):
+            # Below the percentage line, so ACCEPT!
+            assert throttler.throttle('11234', {'ProductName': 'test'}) == (ACCEPT, 50)
+
+        with randommock(0.55):
+            # Above the percentage line, so DEFER!
+            assert throttler.throttle('11234', {'ProductName': 'test'}) == (DEFER, 50)
+
+
+class Testaccept_all:
+    def test_ruleset(self):
+        throttler = Throttler(ConfigManager.from_dict({
+            'THROTTLE_RULES': 'antenna.throttler.accept_all'
+        }))
+
+        answer, percent = throttler.throttle(
+            '11234',
+            {'ProductName': 'Test'}
+        )
+
+        assert answer is ACCEPT
+
+
+class Testmozilla_rules:
+    # NOTE(willkg): This is a rewrite of existing throttler tests in Socorro.
+
+    def test_hangid(self, loggingmock):
+        raw_crash = {
+            'ProductName': 'FireSquid',
+            'Version': '99',
+            'ProcessType': 'browser',
+            'HangID': 'xyz'
+        }
+
+        with loggingmock(['antenna']) as lm:
+            throttler = Throttler(ConfigManager.from_dict({}))
+            answer, percent = throttler.throttle('11234', raw_crash)
+
+            # Reject anything with a HangId and ProcessType = 'browser'
+            assert answer is REJECT
+            assert percent is None
+
+            assert lm.has_record(
+                name='antenna.throttler',
+                levelname='DEBUG',
+                msg_contains='has_hangid_and_browser'
+            )
+
+    def test_comments(self):
+        raw_crash = {
+            'ProductName': 'Test',
+            'Comments': 'foo bar baz'
+        }
+
+        throttler = Throttler(ConfigManager.from_dict({}))
+        answer, percent = throttler.throttle('11234', raw_crash)
+
+        # Reject anything with a HangId and ProcessType = 'browser'
+        assert answer is ACCEPT
+        assert percent is 100


### PR DESCRIPTION
This adds a throttler that behaves much like the throttler in the
current Socorro. There are some minor differences.

First, this throttler defines rule sets in Python. That makes things a
lot easier.

Second, this throttler merges DISCARD and IGNORE because in both cases
we're dropping the crash. Merging them simplifies the code a bit.

Third, this throttler names the rules. This will make logging better
plus it enables us to statsd our rules so we have some metrics about why
things tend to get accepted.

Fourth, other than configurable rule sets, the throttler is not
configurable. If you don't want throttling, use the "accept_all" rule
set.