### PR TITLE
Bug 1316431: Add /__broken__ endpoint

### DIFF
--- a/antenna/app.py
+++ b/antenna/app.py
@@ -16,7 +16,12 @@ from raven.middleware import Sentry
 
 from antenna import metrics
 from antenna.breakpad_resource import BreakpadSubmitterResource
-from antenna.health_resource import HeartbeatResource, LBHeartbeatResource, VersionResource
+from antenna.health_resource import (
+    BrokenResource,
+    HeartbeatResource,
+    LBHeartbeatResource,
+    VersionResource,
+)
 
 
 logger = logging.getLogger(__name__)
@@ -249,6 +254,7 @@ def get_app(config=None):
         app.add_route('version', '/__version__', VersionResource(config, basedir=app_config('basedir')))
         app.add_route('heartbeat', '/__heartbeat__', HeartbeatResource(config, app))
         app.add_route('lbheartbeat', '/__lbheartbeat__', LBHeartbeatResource(config))
+        app.add_route('broken', '/__broken__', BrokenResource(config))
 
         log_config(logger, app)
 

--- a/antenna/health_resource.py
+++ b/antenna/health_resource.py
@@ -7,6 +7,7 @@ import json
 import logging
 from pathlib import Path
 
+from everett.component import RequiredConfigMixin
 import falcon
 
 from antenna import metrics
@@ -14,6 +15,16 @@ from antenna import metrics
 
 logger = logging.getLogger(__name__)
 mymetrics = metrics.get_metrics(__name__)
+
+
+class BrokenResource(RequiredConfigMixin):
+    """Implements the ``/__broken__`` endpoint"""
+    def __init__(self, config):
+        self.config = config
+
+    def on_get(self, req, resp):
+        # This is intentional breakage
+        raise Exception('intentional exception')
 
 
 class VersionResource:

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -135,3 +135,24 @@ supported.
 
    Generally, if the default connection class is fine, you don't need to do any
    configuration here.
+
+
+Putting Antenna in production
+=============================
+
+Antenna is a WSGI application. We use it with gunicorn and nginx, but it can
+be set up in other ways.
+
+Some things to be aware of when you set up Antenna in production:
+
+1. The following endpoints should require basic auth:
+
+   1. ``/__broken__`` -- This throws an exception. It helps to test Sentry
+      configuration. It's best to put it behind auth.
+   2. ``/__heartbeat__`` -- This is a more intensive health check, so it's best
+      to put it behind auth.
+
+2. The S3 connectivity check requires the credentials that Antenna is using to
+   be able to list the contents of the bucket.
+
+3. FIXME -- note about scaling based on RAM usage

--- a/tests/unittest/test_health_resource.py
+++ b/tests/unittest/test_health_resource.py
@@ -41,3 +41,7 @@ class TestHealthChecks:
             resp.content ==
             b'{"errors": [], "info": {"BreakpadSubmitterResource.queue_size": 0}}'
         )
+
+    def test_broken(self, client):
+        resp = client.simulate_get('/__broken__')
+        assert resp.status_code == 500


### PR DESCRIPTION
This adds a /__broken__ endpoint which we can use to trigger exceptions
which Sentry will catch which lets us test Sentry is working.