### PR TITLE
Fix content-length tests

### DIFF
--- a/antenna/breakpad_resource.py
+++ b/antenna/breakpad_resource.py
@@ -134,6 +134,10 @@ class BreakpadSubmitterResource(RequiredConfigMixin):
 
         content_length = req.content_length or 0
 
+        # If there's no content, return an empty crash
+        if content_length == 0:
+            return {}, {}
+
         # Decompress payload if it's compressed
         if req.env.get('HTTP_CONTENT_ENCODING') == 'gzip':
             self.mymetrics.incr('gzipped_crash')
@@ -154,10 +158,6 @@ class BreakpadSubmitterResource(RequiredConfigMixin):
             data = io.BytesIO(data)
         else:
             data = io.BytesIO(req.stream.read(req.content_length or 0))
-
-        # If there's no content, return an empty crash
-        if content_length == 0:
-            return {}, {}
 
         fs = cgi.FieldStorage(fp=data, environ=req.env, keep_blank_values=1)
 

--- a/tests/systemtest/test_discards.py
+++ b/tests/systemtest/test_discards.py
@@ -36,6 +36,9 @@ class TestDiscarded:
         """Test crash with no payload is discarded"""
         raw_crash, dumps = crash_generator.generate()
         payload, headers = mini_poster.multipart_encode(raw_crash)
+        # Zero out the content-length because we're sending an empty
+        # payload.
+        headers['Content-Length'] = '0'
 
         # Send no payload
         resp = requests.post(posturl, headers=headers, data='')


### PR DESCRIPTION
This cleans up the content-length handling code and the tests--the
test_no_content_length test was accidentally sending a content length.

This adds a test for when the content-length is more than the size of
the payload. This requires testing against nginx which will timeout the
connection after a minute (the right thing to do).