### PR TITLE
Bug 1322077: Fix zlib issue

### DIFF
--- a/tests/systemtest/test_content_length.py
+++ b/tests/systemtest/test_content_length.py
@@ -35,7 +35,7 @@ class TestContentLength:
         resp = http_post(posturl, headers, payload)
 
         assert resp.getcode() == 200
-        assert str(resp.read(), encoding='utf-8') == 'Discarded=1'
+        assert str(resp.read(), encoding='utf-8').startswith('CrashID=')
 
     def test_content_length_0(self, posturl, crash_generator):
         """Post a crash with a content-length 0"""


### PR DESCRIPTION
If the payload isn't compressed or zlib throws an error when
uncompressing the payload, we should treat it as junk and move on.