### PR TITLE
Bug 1329998: Split save_raw_crash up

### DIFF
--- a/antenna/breakpad_resource.py
+++ b/antenna/breakpad_resource.py
@@ -316,15 +316,20 @@ class BreakpadSubmitterResource(RequiredConfigMixin):
     def save_crash_to_storage(self, raw_crash, dumps, crash_id):
         """Saves the crash to storage"""
 
-        # FIXME(willkg): How to deal with errors here? The save_raw_crash should
-        # handle retrying, so if it bubbles up to this point, then it's an
-        # unretryable unhandleable error.
+        # FIXME(willkg): How to deal with errors here? These should handle
+        # retrying, so if it bubbles up to this point, then it's an unretryable
+        # unhandleable error.
 
-        # Save the crash to crashstorage
+        # Save dumps to crashstorage
+        self.crashstorage.save_dumps(
+            crash_id,
+            dumps
+        )
+
+        # Save the raw crash metadata to crashstorage
         self.crashstorage.save_raw_crash(
             crash_id,
-            raw_crash,
-            dumps
+            raw_crash
         )
         logger.info('%s saved', crash_id)
 

--- a/tests/unittest/test_crashstorage.py
+++ b/tests/unittest/test_crashstorage.py
@@ -38,21 +38,35 @@ class TestCrashStorage:
         # crashstorage, verify there's only one crash in it and then verify the
         # contents of the crash.
         crashstorage = bsr.crashstorage
-        assert len(crashstorage.crashes) == 1
-        crash = crashstorage.crashes[0]
+        # 1 raw crash and 1 dump
+        assert len(crashstorage.saved_things) == 2
+
+        # First thing is the dump
         assert (
-            crash['raw_crash'] ==
+            crashstorage.saved_things[0] ==
             {
-                'ProductName': 'Test',
-                'Version': '1.0',
-                'dump_checksums': {'upload_file_minidump': 'e19d5cd5af0378da05f63f891c7467af'},
-                'legacy_processing': 0,
-                'percentage': 100,
-                'submitted_timestamp': '2011-09-06T00:00:00+00:00',
-                'timestamp': 1315267200.0,
-                'type_tag': 'bp',
-                'uuid': 'de1bb258-cbbf-4589-a673-34f800160918'
+                'crash_id': 'de1bb258-cbbf-4589-a673-34f800160918',
+                'type': 'upload_file_minidump',
+                'data': b'abcd1234'
             }
         )
-        assert crash['dumps'] == {'upload_file_minidump': b'abcd1234'}
-        assert crash['crash_id'] == 'de1bb258-cbbf-4589-a673-34f800160918'
+
+        # Second thing is the raw crash metadata
+        assert (
+            crashstorage.saved_things[1] ==
+            {
+                'crash_id': 'de1bb258-cbbf-4589-a673-34f800160918',
+                'type': 'raw_crash',
+                'data': {
+                    'ProductName': 'Test',
+                    'Version': '1.0',
+                    'dump_checksums': {'upload_file_minidump': 'e19d5cd5af0378da05f63f891c7467af'},
+                    'legacy_processing': 0,
+                    'percentage': 100,
+                    'submitted_timestamp': '2011-09-06T00:00:00+00:00',
+                    'timestamp': 1315267200.0,
+                    'type_tag': 'bp',
+                    'uuid': 'de1bb258-cbbf-4589-a673-34f800160918'
+                }
+            }
+        )


### PR DESCRIPTION
This splits save_raw_crash into save_raw_crash and save_dumps. The reason for
this is so that we can save the raw crash independently of the dumps if we need
to and thus reduce S3 work.