### PR TITLE
Fix content-length test and post-crash tests

### DIFF
--- a/tests/systemtest/conftest.py
+++ b/tests/systemtest/conftest.py
@@ -14,9 +14,13 @@ from everett.manager import ConfigManager, ConfigEnvFileEnv, ConfigOSEnv
 import pytest
 
 
-# Add repository root so we can import testlib.
+# Add repository root so we can import testlib
 REPO_ROOT = Path(__file__).parent.parent.parent
 sys.path.insert(0, str(REPO_ROOT))
+
+# Set up logging to log at DEBUG level; this is quelled by pytest except when
+# there are errors
+logging.basicConfig(level=logging.DEBUG)
 
 
 @pytest.fixture
@@ -48,6 +52,13 @@ class S3Connection:
 
         self.logger = logging.getLogger(__name__ + '.s3conn')
         self.conn = self.connect()
+
+    def get_config(self):
+        return {
+            'endpointurl': self.endpointurl,
+            'region': self.region,
+            'bucket': self.bucket
+        }
 
     def connect(self):
         session_kwargs = {}

--- a/tests/systemtest/test_content_length.py
+++ b/tests/systemtest/test_content_length.py
@@ -95,8 +95,10 @@ class TestContentLength:
 
         resp = http_post(posturl, headers, payload)
 
-        assert resp.getcode() == 200
-        assert str(resp.read(), encoding='utf-8') == 'Discarded=1'
+        # Verify we get an HTTP 504 because something timed out waiting for the
+        # HTTP client (us) to send the rest of the data which is expected
+        # because we sent a bad content-length
+        assert resp.getcode() == 504
 
     def test_content_length_non_int(self, posturl, crash_generator):
         """Post a crash with a content-length that isn't an int"""

--- a/tests/systemtest/test_post_crash.py
+++ b/tests/systemtest/test_post_crash.py
@@ -27,14 +27,14 @@ class CrashVerifier:
         self.errors.append(msg)
 
     def raw_crash_key(self, crash_id):
-        return '/v2/raw_crash/{entropy}/{date}/{crashid}'.format(
+        return 'v2/raw_crash/{entropy}/{date}/{crashid}'.format(
             entropy=crash_id[0:3],
             date='20' + crash_id[-6:],
             crashid=crash_id
         )
 
     def dump_names_key(self, crash_id):
-        return '/v1/dump_names/{crashid}'.format(
+        return 'v1/dump_names/{crashid}'.format(
             crashid=crash_id
         )
 
@@ -42,7 +42,7 @@ class CrashVerifier:
         if name in (None, '', 'upload_file_minidump'):
             name = 'dump'
 
-        return '/v1/{name}/{crashid}'.format(
+        return 'v1/{name}/{crashid}'.format(
             name=name,
             crashid=crash_id
         )
@@ -225,6 +225,7 @@ class TestPostCrash:
 
         crash_id = content_to_crashid(resp.content)
         logger.debug('Crash ID is: %s', crash_id)
+        logger.debug('S3conn: %s', s3conn.get_config())
 
         verifier = CrashVerifier()
         verifier.verify_crash_data(crash_id, raw_crash, dumps, s3conn)
@@ -246,6 +247,7 @@ class TestPostCrash:
 
         crash_id = content_to_crashid(resp.content)
         logger.debug('Crash ID is: %s', crash_id)
+        logger.debug('S3conn: %s', s3conn.get_config())
 
         verifier = CrashVerifier()
         verifier.verify_crash_data(crash_id, raw_crash, dumps, s3conn)


### PR DESCRIPTION
* the content-length test should be checking for a 504--not a 200
* the post-crash tests were verifying using pseudo-filenames that ended up with
  // in them which I'm pretty sure caused them to fail
* added some more debug logging so failures are easier to debug

@milescrabill Does this look ok?