### PR TITLE
Bug 1325388: Fix parity problems

### DIFF
--- a/tests/unittest/test_breakpad_resource.py
+++ b/tests/unittest/test_breakpad_resource.py
@@ -144,7 +144,7 @@ class TestBreakpadSubmitterResource:
             'upload_file_minidump': ('fakecrash.dump', io.BytesIO(b'abcd1234')),
 
             'legacy_processing': '0',  # ACCEPT
-            'percentage': '100',
+            'throttle_rate': '100',
         })
 
         with loggingmock(['antenna']) as lm:
@@ -161,7 +161,7 @@ class TestBreakpadSubmitterResource:
                 msg_contains='%s: matched by ALREADY_THROTTLED; returned ACCEPT' % crash_id
             )
 
-    @pytest.mark.parametrize('legacy,percentage', [
+    @pytest.mark.parametrize('legacy,throttle_rate', [
         # One of the two is a non-int
         ('foo', 'bar'),
         ('0', 'bar'),
@@ -170,10 +170,10 @@ class TestBreakpadSubmitterResource:
         # legacy_processing is not a valid value
         ('1000', '100'),
 
-        # percentage is not valid
+        # throttle_rate is not valid
         ('0', '1000')
     ])
-    def test_legacy_processing_bad_values(self, legacy, percentage, client, loggingmock):
+    def test_legacy_processing_bad_values(self, legacy, throttle_rate, client, loggingmock):
         crash_id = 'de1bb258-cbbf-4589-a673-34f800160918'
         data, headers = multipart_encode({
             'uuid': crash_id,
@@ -181,9 +181,9 @@ class TestBreakpadSubmitterResource:
             'Version': '1.0',
             'upload_file_minidump': ('fakecrash.dump', io.BytesIO(b'abcd1234')),
 
-            # These are invalid values for legacy_processing and percentage
+            # These are invalid values for legacy_processing and throttle_rate
             'legacy_processing': legacy,
-            'percentage': percentage
+            'throttle_rate': throttle_rate
         })
 
         with loggingmock(['antenna']) as lm:

--- a/tests/unittest/test_crashstorage.py
+++ b/tests/unittest/test_crashstorage.py
@@ -62,7 +62,7 @@ class TestCrashStorage:
                     'Version': '1.0',
                     'dump_checksums': {'upload_file_minidump': 'e19d5cd5af0378da05f63f891c7467af'},
                     'legacy_processing': 0,
-                    'percentage': 100,
+                    'throttle_rate': 100,
                     'submitted_timestamp': '2011-09-06T00:00:00+00:00',
                     'timestamp': 1315267200.0,
                     'type_tag': 'bp',

--- a/tests/unittest/test_fs_crashstorage.py
+++ b/tests/unittest/test_fs_crashstorage.py
@@ -78,8 +78,8 @@ class TestFSCrashStorage:
                 b'"Version": "1.0", ' +
                 b'"dump_checksums": {"upload_file_minidump": "e19d5cd5af0378da05f63f891c7467af"}, ' +
                 b'"legacy_processing": 0, ' +
-                b'"percentage": 100, ' +
                 b'"submitted_timestamp": "2011-09-06T00:00:00+00:00", ' +
+                b'"throttle_rate": 100, ' +
                 b'"timestamp": 1315267200.0, ' +
                 b'"type_tag": "bp", ' +
                 b'"uuid": "de1bb258-cbbf-4589-a673-34f800160918"}'
@@ -141,7 +141,7 @@ class TestFSCrashStorage:
                 'Version': '1.0',
                 'dump_checksums': {'upload_file_minidump': 'e19d5cd5af0378da05f63f891c7467af'},
                 'legacy_processing': 0,
-                'percentage': 100,
+                'throttle_rate': 100,
                 'submitted_timestamp': '2011-09-06T00:00:00+00:00',
                 'timestamp': 1315267200.0,
                 'type_tag': 'bp',


### PR DESCRIPTION
This fixes a couple of minor differences in raw_crash files between the current
Socorro collector and Antenna. For some reason, when writing Antenna, I renamed
"throttle_rate" to "percentage". Probably to line up with the new Rule system
architecture I had. Who knows. Anyhow, fixed.