### PR TITLE
Bug 1336533: Switch gauge to histogram

### DIFF
--- a/antenna/breakpad_resource.py
+++ b/antenna/breakpad_resource.py
@@ -163,10 +163,10 @@ class BreakpadSubmitterResource(RequiredConfigMixin):
             content_length = len(data)
 
             data = io.BytesIO(data)
-            self.mymetrics.gauge('crash_size.compressed', content_length)
+            self.mymetrics.histogram('crash_size.compressed', content_length)
         else:
             data = io.BytesIO(req.stream.read(req.content_length or 0))
-            self.mymetrics.gauge('crash_size.uncompressed', content_length)
+            self.mymetrics.histogram('crash_size.uncompressed', content_length)
 
         fs = cgi.FieldStorage(fp=data, environ=req.env, keep_blank_values=1)
 

--- a/antenna/metrics.py
+++ b/antenna/metrics.py
@@ -69,6 +69,9 @@ class LoggingMetrics(RequiredConfigMixin):
     def timing(self, stat, **kwargs):
         self._log('timing', stat, kwargs)
 
+    def histogram(self, stat, **kwargs):
+        self._log('histogram', stat, kwargs)
+
 
 class DogStatsdMetrics(RequiredConfigMixin):
     """Uses the Datadog DogStatsd client for statsd pings."""
@@ -111,6 +114,9 @@ class DogStatsdMetrics(RequiredConfigMixin):
 
     def timing(self, stat, value):
         self.client.timing(metric=stat, value=value)
+
+    def histogram(self, stat, value):
+        self.client.histogram(metric=stat, value=value)
 
 
 def metrics_configure(metrics_class, config):
@@ -191,10 +197,23 @@ class MetricsInterface:
     def timing(self, stat, value):
         """Send timing information
 
-        Note: value is in ms.
+        .. Note::
+
+           value is in ms.
 
         """
         _metrics_impl.timing(self._full_stat(stat), value=value)
+
+    def histogram(self, stat, value):
+        """Send data information which gets rolled as a histogram
+
+        .. Note::
+
+           For metrics systems that don't have histogram, this will do the same
+           as timing.
+
+        """
+        _metrics_impl.histogram(self._full_stat(stat), value=value)
 
     @contextlib.contextmanager
     def timer(self, stat):
@@ -287,6 +306,9 @@ class MetricsMock:
 
     def timing(self, stat, **kwargs):
         self._add_record('timing', stat, kwargs)
+
+    def histogram(self, stat, **kwargs):
+        self._add_record('histogram', stat, kwargs)
 
     def __enter__(self):
         self.records = []


### PR DESCRIPTION
We want histogram stats for crash sizes since we want to know median, 95% and
max. Gauge is the wrong thing for that. This fixes it.