### PR TITLE
Bug 1342525: Fix queuing of s3 uploads

### DIFF
--- a/tests/unittest/test_breakpad_resource.py
+++ b/tests/unittest/test_breakpad_resource.py
@@ -3,7 +3,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import io
-import json
 
 from everett.manager import ConfigManager
 import pytest

--- a/tests/unittest/test_health_resource.py
+++ b/tests/unittest/test_health_resource.py
@@ -38,8 +38,14 @@ class TestHealthChecks:
         # NOTE(willkg): This isn't mocked out, so it's entirely likely that
         # this expected result will change over time.
         assert (
-            resp.content ==
-            b'{"errors": [], "info": {"BreakpadSubmitterResource.queue_size": 0}}'
+            resp.json ==
+            {
+                'errors': [],
+                'info': {
+                    'BreakpadSubmitterResource.save_queue_size': 0,
+                    'BreakpadSubmitterResource.active_save_workers': 0
+                }
+            }
         )
 
     def test_broken(self, client):


### PR DESCRIPTION
Previously, uploading crash data to s3 would happen concurrently and Antenna
would spin off a new coroutine for every crash it was handling. That doesn't
scale.

This changes it so that there's an explicit queue and we cap the number of
actively saving-to-s3 coroutines at CONCURRENT_SAVES.