### PR TITLE
Bug 1342619: Make boto3 client creation retryable

### DIFF
--- a/tests/unittest/test_s3_crashstorage.py
+++ b/tests/unittest/test_s3_crashstorage.py
@@ -232,9 +232,10 @@ class TestS3MockLogging:
             # Verify the retry decorator logged something
             assert lm.has_record(
                 name='antenna.ext.s3.connection',
-                levelname='ERROR',
+                levelname='WARNING',
                 msg_contains='retry attempt 0'
             )
+
         # Assert we did the entire s3 conversation
         assert s3mock.remaining_conversation() == []
 


### PR DESCRIPTION
This reworks the retry code so it's easier to work with. It also changes boto3
client creation so that it gets retried a few times if it fails.

The theory here is that in Antenna -stage, the boto3 lib does an HTTP request to
get the credentials, gets rate-limited and then fails and that hoses Antenna's
ability to start up. Assuming the theory is right, this will alleviate that a
bit.