### PR TITLE
Add crash save metric

### DIFF
--- a/antenna/breakpad_resource.py
+++ b/antenna/breakpad_resource.py
@@ -409,6 +409,8 @@ class BreakpadSubmitterResource(RequiredConfigMixin):
         # milliseconds, so we multiply!
         delta = (time.time() - raw_crash['timestamp']) * 1000
         self.mymetrics.timing('crash_handling.time', delta)
+
+        self.mymetrics.incr('crash_save', 1)
         logger.info('%s saved', crash_id)
 
     def join_pool(self):


### PR DESCRIPTION
This lets us compare number of crashes accepted (which happens whe the crash is
taken in by the WSGI handler) vs. number of crashes saved to s3. If these two
numbers get very far apart, then it's an indicator that things are not good.