### PR TITLE
Bug 1342606: Move health stats to a heartbeat

### DIFF
--- a/tests/unittest/conftest.py
+++ b/tests/unittest/conftest.py
@@ -49,7 +49,7 @@ def request_generator():
 
 class AntennaTestClient(TestClient):
     """Test client to ease testing with Antenna API"""
-    def rebuild_app(self, new_config=None):
+    def rebuild_app(self, new_config):
         """Rebuilds the app
 
         This is helpful if you've changed configuration and need to rebuild the
@@ -58,8 +58,6 @@ class AntennaTestClient(TestClient):
         :arg new_config: dict of configuration to build the new app with
 
         """
-        if new_config is None:
-            new_config = {}
         self.app = get_app(ConfigManager.from_dict(new_config))
 
     def join_app(self):

--- a/tests/unittest/test_breakpad_resource.py
+++ b/tests/unittest/test_breakpad_resource.py
@@ -229,6 +229,11 @@ class TestBreakpadSubmitterResource:
             )
 
     def test_queuing(self, client):
+        def check_health(active_save_workers, save_queue_size):
+            bpr = client.get_resource_by_name('breakpad')
+            assert len(bpr.save_queue) == save_queue_size
+            assert len(bpr.pipeline_pool) == active_save_workers
+
         # Rebuild the app so the client only saves one crash at a time to s3
         client.rebuild_app({
             'CONCURRENT_SAVES': '1'
@@ -241,33 +246,24 @@ class TestBreakpadSubmitterResource:
             'upload_file_minidump': ('fakecrash.dump', io.BytesIO(b'abcd1234'))
         })
 
-        health = client.simulate_get('/__heartbeat__').json
         # Verify initial conditions are correct--no active coroutines and
         # nothing in the save queue
-        assert health['info']['BreakpadSubmitterResource.active_save_workers'] == 0
-        assert health['info']['BreakpadSubmitterResource.save_queue_size'] == 0
+        check_health(active_save_workers=0, save_queue_size=0)
 
         # Submit a crash
         client.simulate_post('/submit', headers=headers, body=data)
-        health = client.simulate_get('/__heartbeat__').json
         # Now there's one coroutine active and one item in the save queue
-        assert health['info']['BreakpadSubmitterResource.active_save_workers'] == 1
-        assert health['info']['BreakpadSubmitterResource.save_queue_size'] == 1
+        check_health(active_save_workers=1, save_queue_size=1)
 
         # Submit another crash
         client.simulate_post('/submit', headers=headers, body=data)
-        health = client.simulate_get('/__heartbeat__').json
         # The coroutine hasn't run yet (we haven't called .join), so there's
         # one coroutine and two queued crashes
-        assert health['info']['BreakpadSubmitterResource.active_save_workers'] == 1
-        assert health['info']['BreakpadSubmitterResource.save_queue_size'] == 2
+        check_health(active_save_workers=1, save_queue_size=2)
 
         # Now join the app and let the coroutines run and make sure the queue clears
         client.join_app()
-
-        health = client.simulate_get('/__heartbeat__').json
         # No more coroutines and no more save queue
-        assert health['info']['BreakpadSubmitterResource.active_save_workers'] == 0
-        assert health['info']['BreakpadSubmitterResource.save_queue_size'] == 0
+        check_health(active_save_workers=0, save_queue_size=0)
 
     # FIXME: test crash report shapes (multiple dumps? no dumps? what else is in there?)

--- a/tests/unittest/test_health_resource.py
+++ b/tests/unittest/test_health_resource.py
@@ -42,8 +42,6 @@ class TestHealthChecks:
             {
                 'errors': [],
                 'info': {
-                    'BreakpadSubmitterResource.save_queue_size': 0,
-                    'BreakpadSubmitterResource.active_save_workers': 0
                 }
             }
         )


### PR DESCRIPTION
Previously, Antenna would emit health stats for the save queue size and active
worker pool size as statsd data when /__heartbeat__ was handled. However, that
only gets handled by one process on the node, so the data we're getting back
from a node isn't the whole story and we won't get back data from orphaned
processes that aren't handling HTTP requests.

This changes the architecture so that BreakpadResource has a heartbeat coroutine
that sleeps 30 seconds and then emits stats.