### PR TITLE
Log batched stats

### DIFF
--- a/antenna/metrics.py
+++ b/antenna/metrics.py
@@ -118,6 +118,7 @@ class DogStatsdMetrics(RequiredConfigMixin):
     def flush_batch(self):
         for key, val in self.batch:
             self.incr(key, val)
+        logger.debug('metrics batch: %r', dict(self.batch))
         self.batch = {}
 
     def incr(self, stat, value=1):


### PR DESCRIPTION
We're having possibly problems with datadog and metrics. This tosses the batched
counter metrics to the logs so we have a way to double-check.