### PR TITLE
Bug 1347185: fix s3 connection problems

### DIFF
--- a/antenna/ext/s3/connection.py
+++ b/antenna/ext/s3/connection.py
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 
 
 def wait_times_save():
-    """Wait time generator for failed save attempts
+    """Wait time generator for failed save and connection attempts
 
     This waits 2 seconds between failed save attempts for 5 iterations and then
     gives up.
@@ -110,6 +110,11 @@ class S3Connection(RequiredConfigMixin):
             # FIXME(willkg): Seems like botocore always raises ClientError
             # which is unhelpful for granularity purposes.
             ClientError,
+
+            # This raises a ValueError "invalid endpoint" if it has problems
+            # getting the s3 credentials and then tries "s3..amazonaws.com"--we
+            # want to retry that, too.
+            ValueError,
         ],
         wait_time_generator=wait_times_save,
         sleep_function=gevent.sleep,

--- a/antenna/heartbeat.py
+++ b/antenna/heartbeat.py
@@ -69,7 +69,7 @@ class HeartbeatManager(RequiredConfigMixin):
             for fun in _registered_hb_funs:
                 try:
                     with capture_unhandled_exceptions():
-                        logger.debug('hb: running %s', fun.__qualname__)
+                        # logger.debug('hb: running %s', fun.__qualname__)
                         fun()
                 except Exception:
                     logger.exception('Exception thrown while retrieving health stats')

--- a/antenna/metrics.py
+++ b/antenna/metrics.py
@@ -116,10 +116,11 @@ class DogStatsdMetrics(RequiredConfigMixin):
         return DogStatsd(host=host, port=port, namespace=namespace)
 
     def flush_batch(self):
-        for key, val in self.batch.items():
-            self.incr(key, val)
-        logger.debug('metrics batch: %r', sorted(self.batch.items()))
-        self.batch = {}
+        if self.batch:
+            for key, val in self.batch.items():
+                self.incr(key, val)
+            logger.debug('metrics batch: %r', sorted(self.batch.items()))
+            self.batch = {}
 
     def incr(self, stat, value=1):
         self.client.increment(metric=stat, value=value)

--- a/antenna/sentry.py
+++ b/antenna/sentry.py
@@ -91,5 +91,6 @@ def capture_unhandled_exceptions():
 
     except Exception:
         if _sentry_client is not None:
+            logger.info('Unhandled exception sent to sentry.')
             _sentry_client.captureException()
         raise


### PR DESCRIPTION
This changes the code to retry ValueError when trying to build a client. We get
a ValueError when boto3 uses the wrong endpoint.

Our theory is that it tries to get credentials and fails for some reason, then
degrades to this endpoint and fails.

Now if it hits this scenario (which seems to happen a lot when we start a new
node), it'll retry 5 times over 10 seconds (might not be enough--we'll find
out).

This also logs a line if it sent something to Sentry.