### PR TITLE
Adjust capture_unhandled_exceptions

### DIFF
--- a/antenna/sentry.py
+++ b/antenna/sentry.py
@@ -93,4 +93,6 @@ def capture_unhandled_exceptions():
         if _sentry_client is not None:
             logger.info('Unhandled exception sent to sentry.')
             _sentry_client.captureException()
+        else:
+            logger.warning('No Sentry client set up.')
         raise


### PR DESCRIPTION
This logs something if the Sentry client isn't set up and that's why it's not
sending unhandled exceptions to Sentry.