### PR TITLE
Log exceptions as one line

### DIFF
--- a/antenna/app.py
+++ b/antenna/app.py
@@ -7,6 +7,7 @@ import logging.config
 import os
 from pathlib import Path
 import socket
+import sys
 
 from everett.manager import ConfigManager, ConfigEnvFileEnv, ConfigOSEnv, parse_class
 from everett.component import ConfigOptions, RequiredConfigMixin
@@ -22,6 +23,7 @@ from antenna.health_resource import (
 )
 from antenna.heartbeat import HeartbeatManager
 from antenna.sentry import set_sentry_client, wsgi_capture_exceptions, capture_unhandled_exceptions
+from antenna.util import one_line_exception
 
 
 logger = logging.getLogger(__name__)
@@ -262,5 +264,5 @@ def get_app(config=None):
         return app
 
     except Exception:
-        logger.exception('Unhandled startup exception')
+        logger.error('Unhandled startup exception: %s', one_line_exception(sys.exc_info()))
         raise

--- a/antenna/util.py
+++ b/antenna/util.py
@@ -7,6 +7,8 @@ from functools import wraps
 import json
 import time
 import uuid
+import sys
+import traceback
 
 import isodate
 
@@ -255,3 +257,18 @@ def retry(retryable_exceptions=Exception,
 
         return _retry_fun
     return _retry_inner
+
+
+def one_line_exception(exc_info=None):
+    """Formats an exception such that it's all on one line
+
+    This fixes some problems with interleaved logging, but it's annoying. To
+    convert the line back do this::
+
+        line.replace('<NL>', '\n')
+
+    """
+    if exc_info is None:
+        exc_info = sys.exc_info()
+
+    return '<NL>'.join(traceback.format_exception(*exc_info)).strip().replace('\n', '<NL>')

--- a/tests/unittest/test_util.py
+++ b/tests/unittest/test_util.py
@@ -3,18 +3,20 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 from datetime import datetime
+import sys
 
 from freezegun import freeze_time
 import pytest
 
 from antenna.util import (
+    MaxAttemptsError,
     create_crash_id,
     de_null,
     get_date_from_crash_id,
     get_throttle_from_crash_id,
+    one_line_exception,
     retry,
-    MaxAttemptsError,
-    utc_now
+    utc_now,
 )
 
 
@@ -190,3 +192,18 @@ class Test_retry:
         with pytest.raises(Exception):
             some_thing()
         assert sleeps == [1, 1, 2, 2, 1, 1]
+
+
+def test_one_line_exception():
+    try:
+        1 / 0
+
+    except ZeroDivisionError:
+        exc_no_args = one_line_exception()
+        exc_args = one_line_exception(sys.exc_info())
+
+    assert '\n' not in exc_no_args
+    assert '\n' not in exc_args
+    assert exc_no_args == exc_args
+
+    assert exc_args.endswith('ZeroDivisionError: division by zero')


### PR DESCRIPTION
Right now we're getting insane interleaved logs which makes extracting
tracebacks impossible. This improves that by changing it so it logs the whole
thing as one line.