### PR TITLE
Bug 1349995: Allow changing host id in logs

### DIFF
--- a/antenna/app.py
+++ b/antenna/app.py
@@ -160,7 +160,8 @@ class AppConfig(RequiredConfigMixin):
             'Identifier for the host that is running Antenna. This identifies this Antenna '
             'instance in the logs and makes it easier to correlate Antenna logs with '
             'other data. For example, the value could be a public hostname, an instance id, '
-            'or something like that.'
+            'or something like that. If you do not set this, then socket.gethostname() is '
+            'used instead.'
         )
     )
 

--- a/tests/unittest/conftest.py
+++ b/tests/unittest/conftest.py
@@ -28,7 +28,10 @@ from testlib.s3mock import S3Mock  # noqa
 
 def pytest_runtest_setup():
     # Make sure we set up logging and metrics to sane default values.
-    setup_logging('DEBUG')
+    setup_logging(ConfigManager.from_dict({
+        'HOST_ID': '',
+        'LOGGING_LEVEL': 'DEBUG',
+    }))
     setup_metrics(metrics.LoggingMetrics, ConfigManager.from_dict({}))
 
     # Wipe any registered heartbeat functions


### PR DESCRIPTION
This makes it possible to set the host id in the logs to whatever you want using
the HOST_ID environment variable. This makes it easier to set the host id to
something that you can later use to correlate items in logs to other data
systems.