### PR TITLE
Send commit as tag to Sentry

### DIFF
--- a/antenna/app.py
+++ b/antenna/app.py
@@ -249,7 +249,7 @@ def get_app(config=None):
         app_config = AppConfig(config)
 
         # Set a Sentry client if we're so configured
-        set_sentry_client(app_config('secret_sentry_dsn'))
+        set_sentry_client(app_config('secret_sentry_dsn'), app_config('basedir'))
 
         with capture_unhandled_exceptions():
             setup_logging(app_config)

--- a/antenna/health_resource.py
+++ b/antenna/health_resource.py
@@ -11,6 +11,7 @@ from everett.component import RequiredConfigMixin
 import falcon
 
 from antenna import metrics
+from antenna.util import get_version_info
 
 
 logger = logging.getLogger(__name__)
@@ -34,17 +35,11 @@ class VersionResource:
         self.basedir = basedir
 
     def on_get(self, req, resp):
-        try:
-            path = Path(self.basedir) / 'version.json'
-            with open(str(path), 'r') as fp:
-                commit_info = fp.read().strip()
-        except (IOError, OSError):
-            logging.error('Exception thrown when retrieving version.json', exc_info=True)
-            commit_info = '{}'
+        version_info = get_version_info(self.basedir)
 
         resp.content_type = 'application/json; charset=utf-8'
         resp.status = falcon.HTTP_200
-        resp.body = commit_info
+        resp.body = version_info
 
 
 class LBHeartbeatResource:

--- a/antenna/health_resource.py
+++ b/antenna/health_resource.py
@@ -5,7 +5,6 @@
 from collections import OrderedDict
 import json
 import logging
-from pathlib import Path
 
 from everett.component import RequiredConfigMixin
 import falcon

--- a/antenna/sentry.py
+++ b/antenna/sentry.py
@@ -14,6 +14,8 @@ import sys
 from raven import Client
 from raven.middleware import Sentry
 
+from antenna.util import get_version_info
+
 
 logger = logging.getLogger(__name__)
 
@@ -21,7 +23,7 @@ logger = logging.getLogger(__name__)
 _sentry_client = None
 
 
-def set_sentry_client(sentry_dsn):
+def set_sentry_client(sentry_dsn, basedir):
     """Sets a Sentry client using a given sentry_dsn
 
     To clear the client, pass in something falsey like ``''`` or ``None``.
@@ -29,7 +31,14 @@ def set_sentry_client(sentry_dsn):
     """
     global _sentry_client
     if sentry_dsn:
-        _sentry_client = Client(dsn=sentry_dsn, include_paths=['antenna'])
+        version_info = get_version_info(basedir)
+        commit = version_info.get('commit')[:8]
+
+        _sentry_client = Client(
+            dsn=sentry_dsn,
+            include_paths=['antenna'],
+            tags={'commit': commit}
+        )
         logger.info('Set up sentry client')
     else:
         _sentry_client = None

--- a/antenna/util.py
+++ b/antenna/util.py
@@ -5,12 +5,17 @@
 import datetime
 from functools import wraps
 import json
-import time
-import uuid
+import logging
+from pathlib import Path
 import sys
+import time
 import traceback
+import uuid
 
 import isodate
+
+
+logger = logging.getLogger(__name__)
 
 
 UTC = isodate.UTC
@@ -38,10 +43,29 @@ def utc_now():
     return datetime.datetime.now(UTC)
 
 
+def get_version_info(basedir):
+    """Given a basedir, retrieves version information for this deploy
+
+    :arg str basedir: the path of the base directory where ``version.json``
+        exists
+
+    :returns: version info as a dict or an empty dict
+
+    """
+    try:
+        path = Path(basedir) / 'version.json'
+        with open(str(path), 'r') as fp:
+            commit_info = fp.read().strip()
+    except (IOError, OSError):
+        logger.error('Exception thrown when retrieving version.json', exc_info=True)
+        commit_info = '{}'
+    return commit_info
+
+
 def de_null(value):
     """Remove nulls from bytes and str values
 
-    :arg value: The str or bytes to remove nulls from
+    :arg str/bytes value: The str or bytes to remove nulls from
 
     :returns: str or bytes without nulls
 


### PR DESCRIPTION
This adjusts the Sentry client creation so that it sends the commit sha of the
deployed code as a tag with all Sentry reports.

The reason we do this instead of sending the release is that this doesn't
require us to create the release every time we do a deploy.