### PR TITLE
Version info fix

### DIFF
--- a/antenna/health_resource.py
+++ b/antenna/health_resource.py
@@ -34,7 +34,7 @@ class VersionResource:
         self.basedir = basedir
 
     def on_get(self, req, resp):
-        version_info = get_version_info(self.basedir)
+        version_info = json.dumps(get_version_info(self.basedir))
 
         resp.content_type = 'application/json; charset=utf-8'
         resp.status = falcon.HTTP_200

--- a/antenna/util.py
+++ b/antenna/util.py
@@ -55,10 +55,10 @@ def get_version_info(basedir):
     try:
         path = Path(basedir) / 'version.json'
         with open(str(path), 'r') as fp:
-            commit_info = fp.read().strip()
+            commit_info = json.loads(fp.read().strip())
     except (IOError, OSError):
         logger.error('Exception thrown when retrieving version.json', exc_info=True)
-        commit_info = '{}'
+        commit_info = {}
     return commit_info
 
 

--- a/tests/unittest/test_util.py
+++ b/tests/unittest/test_util.py
@@ -14,6 +14,7 @@ from antenna.util import (
     de_null,
     get_date_from_crash_id,
     get_throttle_from_crash_id,
+    get_version_info,
     one_line_exception,
     retry,
     utc_now,
@@ -25,6 +26,16 @@ def test_utc_now():
     assert res.strftime('%Z') == 'UTC'
     assert res.strftime('%z') == '+0000'
     assert res.tzinfo
+
+
+def test_get_version_info(tmpdir):
+    fn = tmpdir.join('/version.json')
+    fn.write_text('{"commit": "d6ac5a5d2acf99751b91b2a3ca651d99af6b9db3"}', encoding='utf-8')
+
+    assert (
+        get_version_info(str(tmpdir)) ==
+        {'commit': 'd6ac5a5d2acf99751b91b2a3ca651d99af6b9db3'}
+    )
 
 
 @pytest.mark.parametrize('data,expected', [


### PR DESCRIPTION
`get_version_info` was returning a string--not a dict. The Sentry code was expecting a dict.

This fixes `get_version_info` to return a dict and fixes the `/__version__` endpoint to work with that correctly and adds a test.