### PR TITLE
Bug 1354897: Clean up metrics keys

### DIFF
--- a/antenna/app.py
+++ b/antenna/app.py
@@ -27,7 +27,6 @@ from antenna.util import one_line_exception
 
 
 logger = logging.getLogger(__name__)
-mymetrics = metrics.get_metrics(__name__)
 
 
 def setup_logging(app_config):

--- a/antenna/health_resource.py
+++ b/antenna/health_resource.py
@@ -14,7 +14,7 @@ from antenna.util import get_version_info
 
 
 logger = logging.getLogger(__name__)
-mymetrics = metrics.get_metrics(__name__)
+mymetrics = metrics.get_metrics('health')
 
 
 class BrokenResource(RequiredConfigMixin):

--- a/antenna/throttler.py
+++ b/antenna/throttler.py
@@ -13,6 +13,7 @@ from antenna import metrics
 
 
 logger = logging.getLogger(__name__)
+mymetrics = metrics.get_metrics('throttler')
 
 
 ACCEPT = 0   # save and process
@@ -82,7 +83,6 @@ class Throttler(RequiredConfigMixin):
     def __init__(self, config):
         self.config = config.with_options(self)
         self.rule_set = self.config('throttle_rules')
-        self.mymetrics = metrics.get_metrics(self)
 
     def throttle(self, raw_crash):
         """Go through rule set to ACCEPT, REJECT or DEFER
@@ -96,7 +96,7 @@ class Throttler(RequiredConfigMixin):
             match = rule.match(raw_crash)
 
             if match:
-                self.mymetrics.incr('match_%s' % rule.rule_name)
+                mymetrics.incr('match_%s' % rule.rule_name)
 
                 if rule.percentage is None:
                     return REJECT, rule.rule_name, None

--- a/docs/architecture.rst
+++ b/docs/architecture.rst
@@ -154,10 +154,9 @@ Statsd
 Antenna sends data to statsd. Read the code for what's available where and what
 it means.
 
-Here are some good ones--all are prefixed with
-``antenna.breakpad_resource.BreakpadSubmitterResource``:
+Here are some good ones:
 
-* ``incoming_crash``
+* ``breakpad_resource.incoming_crash``
 
   Counter. Denotes an incoming crash.
 
@@ -165,11 +164,11 @@ Here are some good ones--all are prefixed with
 
   Counters. Throttle results. Possibilities: ``accept``, ``defer``, ``reject``.
 
-* ``save_crash.count``
+* ``breakpad_resource.save_crash.count``
 
   Counter. Denotes a crash has been successfully saved.
 
-* ``save_queue_size``
+* ``breakpad_resource.save_queue_size``
 
   Gauge. Tells you how many things are sitting in the ``crashmover_save_queue``.
 
@@ -178,15 +177,15 @@ Here are some good ones--all are prefixed with
      If this number is > 0, it means that Antenna is having difficulties keeping
      up with incoming crashes.
 
-* ``on_post.time``
+* ``breakpad_resource.on_post.time``
 
   Timing. This is the time it took to handle the HTTP POST request.
 
-* ``crash_save.time``
+* ``breakpad_resource.crash_save.time``
 
   Timing. This is the time it took to save the crash to S3.
 
-* ``crash_handling.time``
+* ``breakpad_resource.crash_handling.time``
 
   Timing. This is the total time the crash was in Antenna-land from receiving
   the crash to saving it to S3.


### PR DESCRIPTION
This reduces a lot of extra stuff in the metrics keys making them shorter and
easier to write out.