### PR TITLE
Bug 1343708: Remove batch_incr

### DIFF
--- a/tests/unittest/test_metrics.py
+++ b/tests/unittest/test_metrics.py
@@ -201,19 +201,6 @@ class TestDogStatsdMetrics:
             mymetrics.incr('key1')
             mock_incr.assert_called_with(metric='foobar.key1', value=1)
 
-    def test_batch_incr(self):
-        metrics.metrics_configure(metrics.DogStatsdMetrics, ConfigManager.from_dict({}))
-        mymetrics = metrics.get_metrics('foobar')
-
-        with patch.object(metrics._metrics_impl.client, 'increment') as mock_incr:
-            mymetrics.batch_incr('key1', 1)
-            mymetrics.batch_incr('key1', 2)
-
-            # Reach in and flush the batch
-            metrics._metrics_impl.flush_batch()
-
-            mock_incr.assert_called_with(metric='foobar.key1', value=3)
-
     def test_timing(self):
         metrics.metrics_configure(metrics.DogStatsdMetrics, ConfigManager.from_dict({}))
         mymetrics = metrics.get_metrics('foobar')


### PR DESCRIPTION
We were having problems where graphs weren't lining up. I did some work and
theorized that since Antenna sends the same value a lot, that some of them were
getting dropped during the "normalize for a flush interval" period. Thus I
implemented batching of counters that occur often.

Since then, I've learned a lot more about statsd and I think all those theories
are rubbish.

Given that the theories are rubbish and while in the bug comments I claim that
batching helped, I don't think it actually did help at all and I think I was
interpreting the data noise incorrectly.

This commit removes the batching code because it's probably not actually helping
at all and thus it's adding unneeded code complexity.