### PR TITLE
Fix throttler

### DIFF
--- a/antenna/throttler.py
+++ b/antenna/throttler.py
@@ -107,8 +107,8 @@ class Throttler(RequiredConfigMixin):
                     response = ACCEPT
                 return response, rule.rule_name, rule.percentage
 
-        # None of the rules matched, so we reject
-        return REJECT, 'NO_MATCH', 0
+        # None of the rules matched, so we defer
+        return DEFER, 'NO_MATCH', 0
 
 
 class Rule:

--- a/tests/unittest/test_throttler.py
+++ b/tests/unittest/test_throttler.py
@@ -177,3 +177,10 @@ class Testmozilla_rules:
 
         throttler = Throttler(ConfigManager.from_dict({}))
         assert throttler.throttle(raw_crash) == (ACCEPT, 'is_thunderbird_seamonkey', 100)
+
+    def test_is_nothing(self):
+        # None of the rules will match an empty crash
+        raw_crash = {}
+
+        throttler = Throttler(ConfigManager.from_dict({}))
+        assert throttler.throttle(raw_crash) == (DEFER, 'NO_MATCH', 0)


### PR DESCRIPTION
For crashes that don't match any of the throttler rules, we should defer
them--not reject them. This fixes that.