### PR TITLE
Bug 1356671: Fix crash saving exception handling

### DIFF
--- a/antenna/ext/s3/connection.py
+++ b/antenna/ext/s3/connection.py
@@ -195,7 +195,7 @@ class S3Connection(RequiredConfigMixin):
         """Saves a single file to s3
 
         This will retry a handful of times in short succession so as to deal
-        with # some amount of fishiness. After that, the caller should retry
+        with some amount of fishiness. After that, the caller should retry
         saving after a longer period of time.
 
         :arg str path: the path to save to


### PR DESCRIPTION
* change crash saving retrying so that it only retries 20 times and then gives
  up; each time it sends something to sentry so we shouldn't miss it.
* add a test for the new retry behavior