### PR TITLE
Bug 1356671: Blind fix for None keys in raw_crash

### DIFF
--- a/antenna/breakpad_resource.py
+++ b/antenna/breakpad_resource.py
@@ -261,7 +261,9 @@ class BreakpadSubmitterResource(RequiredConfigMixin):
 
             else:
                 # This isn't a dump, so it's a key/val pair, so we add that.
-                raw_crash[fs_item.name] = de_null(fs_item.value)
+                # NOTE(willkg): We saw some crashes come in where the raw crash ends up with
+                # a None as a key. Make sure we can't end up with non-strings as keys.
+                raw_crash[fs_item.name or ''] = de_null(fs_item.value)
 
         return raw_crash, dumps
 


### PR DESCRIPTION
I can't for the life of me figure out how a None can end up as a key in the
raw_crash. Everything I do to try to coerce extract_payload() into yielding a
None is for naught. Thus this is a blind fix for something I can't reproduce.