### PR TITLE
Bug 1351914: Switch to moto for fake s3

### DIFF
--- a/Dockerfile.motos3
+++ b/Dockerfile.motos3
@@ -1,0 +1,24 @@
+FROM python:3.5.3
+
+MAINTAINER Will Kahn-Greene <willkg@mozilla.com>
+
+# FIXME(willkg): Use a commit on master because 0.4.31 has bugs on buckets. Once a new
+# release has happened, we can switch to that.
+ENV MOTO_VERSION df84675ae67e717449f01fafe3a022eb14984e26
+
+RUN cd /tmp && \
+    wget https://github.com/spulec/moto/archive/$MOTO_VERSION.tar.gz -O moto-$MOTO_VERSION.tar.gz && \
+    tar -xzvf moto-$MOTO_VERSION.tar.gz && \
+    cd moto-$MOTO_VERSION/ && \
+    pip install .[server]
+
+# Expose /opt/moto as a volume
+VOLUME "/opt/moto"
+
+# Port that moto listens on
+EXPOSE 5000
+
+# This spits out --help which isn't helpful, but you can specify what to do
+# by setting the command.
+ENTRYPOINT ["moto_server"]
+CMD ["--help"]

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,6 @@ clean:
 
 	# state files
 	-rm .docker-build
-	ANTENNA_ENV=empty.env ${DC} run --entrypoint "/bin/bash -c 'rm -rf /fakes3_root/*'" fakes3
 
 lint: .docker-build
 	ANTENNA_ENV=empty.env ${DC} run base flake8 --statistics antenna tests/unittest/

--- a/README.rst
+++ b/README.rst
@@ -56,7 +56,7 @@ production, see docs_.
 
          ANTENNA_ENV="dev.env" /usr/bin/docker-compose up web
          antenna_statsd_1 is up-to-date
-         antenna_fakes3_1 is up-to-date
+         antenna_moto-s3_1 is up-to-date
          Recreating antenna_web_1
          Attaching to antenna_web_1
          web_1      | [2016-11-07 15:39:21 +0000] [7] [INFO] Starting gunicorn 19.6.0
@@ -72,18 +72,22 @@ production, see docs_.
          web_1      | [2016-11-07 15:39:21 +0000] [INFO] antenna.app: DUMP_ID_PREFIX=bp-
          web_1      | [2016-11-07 15:39:21 +0000] [INFO] antenna.app: CRASHSTORAGE_CLASS=antenna.ext.s3.crashstorage.S3CrashStorage
          web_1      | [2016-11-07 15:39:21 +0000] [INFO] antenna.app: THROTTLE_RULES=antenna.throttler.mozilla_rules
-         web_1      | [2016-11-07 15:39:21 +0000] [INFO] antenna.app: CRASHSTORAGE_ACCESS_KEY=fakes3
+         web_1      | [2016-11-07 15:39:21 +0000] [INFO] antenna.app: CRASHSTORAGE_ACCESS_KEY=foo
          web_1      | [2016-11-07 15:39:21 +0000] [INFO] antenna.app: CRASHSTORAGE_SECRET_ACCESS_KEY=*****
-         web_1      | [2016-11-07 15:39:21 +0000] [INFO] antenna.app: CRASHSTORAGE_REGION=us-west-2
-         web_1      | [2016-11-07 15:39:21 +0000] [INFO] antenna.app: CRASHSTORAGE_ENDPOINT_URL=http://fakes3:4569
-         web_1      | [2016-11-07 15:39:21 +0000] [INFO] antenna.app: CRASHSTORAGE_BUCKET_NAME=org.fakes3.prod
+         web_1      | [2016-11-07 15:39:21 +0000] [INFO] antenna.app: CRASHSTORAGE_REGION=us-east-1
+         web_1      | [2016-11-07 15:39:21 +0000] [INFO] antenna.app: CRASHSTORAGE_ENDPOINT_URL=http://moto-s3:5000
+         web_1      | [2016-11-07 15:39:21 +0000] [INFO] antenna.app: CRASHSTORAGE_BUCKET_NAME=antennabucket
 
 
    2. Verify things are running:
 
-      In another terminal, you can verify the proper containers are running with
-      ``docker-compose ps``. You should see containers with names ``web``,
-      ``statsd`` and ``fakes3``.
+      In another terminal, you can verify the proper containers are running with:
+
+      .. code-block:: shell
+
+         $ docker-compose ps
+
+      You should see containers with names ``web``, ``statsd`` and ``moto-s3``.
 
    3. Send in a crash report:
 
@@ -109,10 +113,10 @@ production, see docs_.
          web_1      | [2016-11-07 15:48:45 +0000] [INFO] antenna.breakpad_resource: a448814e-16dd-45fb-b7dd-b0b522161010 saved
 
 
-   4. See the data in fakes3:
+   4. See the data in moto-s3:
 
-      The ``fakes3`` container will store data in ``./fakes3_root``, so you can
-      verify the contents of files there.
+      The ``moto-s3`` container will store data in memory. When you shut down the
+      container it goes away. You can use the aws-cli to access it.
 
    5. Look at runtime metrics with Grafana:
 

--- a/antenna/ext/s3/connection.py
+++ b/antenna/ext/s3/connection.py
@@ -172,7 +172,7 @@ class S3Connection(RequiredConfigMixin):
         self.client.head_bucket(Bucket=self.bucket)
 
     def _create_bucket(self):
-        # NOTE(willkg): Don't use this except with fakes3 and dev environments.
+        # NOTE(willkg): Don't use this except with a fake s3 and dev environments.
         self.client.create_bucket(Bucket=self.bucket)
 
     def check_health(self, state):

--- a/bin/create_s3_bucket.py
+++ b/bin/create_s3_bucket.py
@@ -7,7 +7,7 @@
 """When doing local development, we need to create the bucket before we can use
 it. This script makes that easier.
 
-In order for this script to run, you must have the fakes3 container running.
+In order for this script to run, you must have the moto-s3 container running.
 
 If a bucket exists, it won't do anything.
 
@@ -20,6 +20,7 @@ It'll throw an error if something unexpected happened.
 
 """
 
+import logging
 import os
 import sys
 
@@ -29,6 +30,18 @@ from everett.manager import ConfigManager, ConfigEnvFileEnv, ConfigOSEnv
 sys.path.insert(0, os.getcwd())  # noqa
 
 from antenna.ext.s3.connection import S3Connection
+
+
+def _log_everything():
+    # Set up all the debug logging for grossest possible output
+    from http.client import HTTPConnection
+    HTTPConnection.debuglevel = 1
+
+    logging.getLogger('requests').setLevel(logging.DEBUG)
+    logging.getLogger('requests.packages.urllib3').setLevel(logging.DEBUG)
+
+
+_log_everything()
 
 
 def main(args):
@@ -55,7 +68,6 @@ def main(args):
         print(str(exc))
         if 'HeadBucket operation: Not Found' in str(exc):
             print('Bucket not found. Creating %s ...' % conn.bucket)
-            # Create the bucket.
             conn._create_bucket()
             print('Bucket created.')
         else:

--- a/bin/create_s3_bucket.py
+++ b/bin/create_s3_bucket.py
@@ -41,7 +41,7 @@ def _log_everything():
     logging.getLogger('requests.packages.urllib3').setLevel(logging.DEBUG)
 
 
-_log_everything()
+# _log_everything()
 
 
 def main(args):

--- a/dev.env
+++ b/dev.env
@@ -1,4 +1,4 @@
-# prod-like Antenna environment with fakes3.
+# prod-like Antenna environment with moto-s3.
 #
 # See https://antenna.readthedocs.io/ for documentation.
 
@@ -14,7 +14,8 @@ STATSD_NAMESPACE=mcboatface
 CRASHSTORAGE_CLASS=antenna.ext.s3.crashstorage.S3CrashStorage
 
 # S3CrashStorage and S3Connection settings
-CRASHSTORAGE_ENDPOINT_URL=http://fakes3:4569
-CRASHSTORAGE_ACCESS_KEY=fakes3
-CRASHSTORAGE_SECRET_ACCESS_KEY=whatever
-CRASHSTORAGE_BUCKET_NAME=org.fakes3.prod
+CRASHSTORAGE_ENDPOINT_URL=http://moto-s3:5000
+CRASHSTORAGE_REGION=us-east-1
+CRASHSTORAGE_ACCESS_KEY=foo
+CRASHSTORAGE_SECRET_ACCESS_KEY=foo
+CRASHSTORAGE_BUCKET_NAME=antennabucket

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,7 +41,7 @@ services:
       - "8000:8000"
     command: ./bin/run_web.sh
     links:
-      - fakes3
+      - moto-s3
       - statsd
 
   # System test container
@@ -55,14 +55,13 @@ services:
     links:
       - web
 
-  # fakes3 service
-  # https://hub.docker.com/r/lphoward/fake-s3/
-  fakes3:
-    image: lphoward/fake-s3
+  moto-s3:
+    build:
+      context: .
+      dockerfile: Dockerfile.motos3
+    command: s3 -H 0.0.0.0 -p5000
     ports:
-      - "4569:4569"
-    volumes:
-      - ./fakes3_root:/fakes3_root
+      - "5000:5000"
 
   statsd:
     # https://hub.docker.com/r/kamon/grafana_graphite/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,6 +55,7 @@ services:
     links:
       - web
 
+  # moto-server running a fake S3
   moto-s3:
     build:
       context: .
@@ -63,9 +64,9 @@ services:
     ports:
       - "5000:5000"
 
+  # https://hub.docker.com/r/kamon/grafana_graphite/
+  # username: admin, password: admin
   statsd:
-    # https://hub.docker.com/r/kamon/grafana_graphite/
-    # username: admin, password: admin
     image: kamon/grafana_graphite
     ports:
       - "9000:3000"  # grafana port

--- a/tests/systemtest/README.rst
+++ b/tests/systemtest/README.rst
@@ -65,7 +65,7 @@ following items defined in it::
     the node this is running on to require these.
 
 ``CRASHSTORAGE_ENDPOINT_URL``
-    If you're using fakes3, you need to define this.
+    If you're using a fake s3 (for example, moto), you need to define this.
 
 ``CRASHSTORAGE_REGION``
     The regeion you're using. Defaults to ``us-west-2``.


### PR DESCRIPTION
This switches from fake s3 to moto. This solves several problems the biggest of
which being that they no longer distribute fakes3 under and Open Source license.

The other problem this solves is that fakes3 doesn't let you list buckets which
we now need.

This uses a specific commit in the master branch after release 0.4.31 because
that release has bugs that prevent us from creating buckets.