### PR TITLE
Bug 1357452: Fix extract_payload to de-null keys and filenames

### DIFF
--- a/tests/unittest/test_util.py
+++ b/tests/unittest/test_util.py
@@ -45,6 +45,7 @@ def test_get_version_info(tmpdir):
     (123, 123),
 
     # has nulls
+    ('abc\u0000', 'abc'),
     ('abc\0', 'abc'),
     ('ab\0c\0', 'abc'),
     (b'abc\0', b'abc'),


### PR DESCRIPTION
This adds de-nulling to keys and filenames in addition to values which Antenna
already did.