### PR TITLE
Bug 1357944: Move incr for throttle rule

### DIFF
--- a/antenna/breakpad_resource.py
+++ b/antenna/breakpad_resource.py
@@ -387,6 +387,7 @@ class BreakpadSubmitterResource(RequiredConfigMixin):
         # Log the throttle result
         logger.info('%s: matched by %s; returned %s', crash_id, rule_name,
                     RESULT_TO_TEXT[throttle_result])
+        mymetrics.incr('throttle_rule', tags=['rule:%s' % rule_name])
         mymetrics.incr('throttle', tags=['result:%s' % RESULT_TO_TEXT[throttle_result].lower()])
 
         if throttle_result is REJECT:

--- a/antenna/throttler.py
+++ b/antenna/throttler.py
@@ -8,11 +8,9 @@ import random
 import re
 
 from everett.component import ConfigOptions, RequiredConfigMixin
-import markus
 
 
 logger = logging.getLogger(__name__)
-mymetrics = markus.get_metrics('throttler')
 
 
 ACCEPT = 0   # save and process
@@ -95,8 +93,6 @@ class Throttler(RequiredConfigMixin):
             match = rule.match(raw_crash)
 
             if match:
-                mymetrics.incr('throttle_match', tags=['rule:%s' % rule.rule_name])
-
                 if rule.percentage is None:
                     return REJECT, rule.rule_name, None
 


### PR DESCRIPTION
This moves the incr for the throttle rule into the breakpad_resource to a place
where we have the rule used even if we picked a rule without running through the
throttler.

This will additionally cover NO_MATCH, THROTTLEABLE_0, ALREADY_THROTTLED, and
FROM_CRASHID.