### PR TITLE
Add .pyup.yml

### DIFF
--- a/.pyup.yml
+++ b/.pyup.yml
@@ -1,0 +1,7 @@
+schedule: "every day"
+search: False
+requirements:
+  - requirements.txt:
+      updates: security
+  - requirements-newrelic.txt:
+      updates: security


### PR DESCRIPTION
refs:
* [bug 1356367](https://bugzilla.mozilla.org/show_bug.cgi?id=1356367)
* https://github.com/mozilla-services/foxsec/issues/289

Add daily python dependency checking via pyup.

Should I split the dev requirements into a separate file?

r? @peterbe or @willkg

possible followups / TODO:

- [ ] move antenna to the mozilla-services github org since we're trying to limit integrations with access to the main mozilla gh org
- [ ] enable the pyup integration https://github.com/mozilla-services/github-management#mozilla-services-github-organization-management
- [ ] badge in readme