### PR TITLE
Clean up content-types in responses

### DIFF
--- a/antenna/app.py
+++ b/antenna/app.py
@@ -198,17 +198,6 @@ class AppConfig(RequiredConfigMixin):
         return self.config(key)
 
 
-class HomePageResource:
-    """Shows something at /"""
-    def __init__(self, config):
-        pass
-
-    def on_get(self, req, resp):
-        resp.content_type = 'text/html'
-        resp.status = falcon.HTTP_404
-        resp.body = '<html><body><!-- Antenna --><p>HTTP 404: Not found.</p></body></html>'
-
-
 class AntennaAPI(falcon.API):
     def __init__(self, config):
         super().__init__()
@@ -290,7 +279,6 @@ def get_app(config=None):
 
             app = AntennaAPI(config)
 
-            app.add_route('homepage', '/', HomePageResource(config))
             app.add_route('breakpad', '/submit', BreakpadSubmitterResource(config))
             app.add_route('version', '/__version__', VersionResource(config, basedir=app_config('basedir')))
             app.add_route('heartbeat', '/__heartbeat__', HeartbeatResource(config, app))

--- a/antenna/breakpad_resource.py
+++ b/antenna/breakpad_resource.py
@@ -349,6 +349,8 @@ class BreakpadSubmitterResource(RequiredConfigMixin):
         resp.status = falcon.HTTP_200
 
         start_time = time.time()
+        # NOTE(willkg): This has to return text/plain since that's what the
+        # breakpad clients expect.
         resp.content_type = 'text/plain'
 
         raw_crash, dumps = self.extract_payload(req)

--- a/antenna/health_resource.py
+++ b/antenna/health_resource.py
@@ -18,7 +18,7 @@ mymetrics = markus.get_metrics('health')
 
 
 class BrokenResource(RequiredConfigMixin):
-    """Implements the ``/__broken__`` endpoint"""
+    """Handles ``/__broken__`` endpoint"""
     def __init__(self, config):
         self.config = config
 
@@ -28,7 +28,7 @@ class BrokenResource(RequiredConfigMixin):
 
 
 class VersionResource:
-    """Implements the ``/__version__`` endpoint"""
+    """Handles ``/__version__`` endpoint"""
     def __init__(self, config, basedir):
         self.config = config
         self.basedir = basedir
@@ -42,11 +42,12 @@ class VersionResource:
 
 
 class LBHeartbeatResource:
-    """Endpoint to let the load balancing know application health"""
+    """Handles ``/__lbheartbeat__`` to let the load balancing know application health"""
     def __init__(self, config):
         self.config = config
 
     def on_get(self, req, resp):
+        resp.content_type = 'application/json; charset=utf-8'
         resp.status = falcon.HTTP_200
 
 
@@ -80,7 +81,7 @@ class HealthState:
 
 
 class HeartbeatResource:
-    """Handles /__heartbeat__"""
+    """Handles ``/__heartbeat__`` for app health"""
     def __init__(self, config, app):
         self.config = config
         self.antenna_app = app

--- a/antenna/sentry.py
+++ b/antenna/sentry.py
@@ -61,10 +61,10 @@ class WSGILoggingMiddleware(object):
             exc_info = sys.exc_info()
             start_response(
                 '500 Internal Server Error',
-                [('content-type', 'text/plain')],
+                [('content-type', 'application/json; charset=utf-8')],
                 exc_info
             )
-            return [b'COUGH! Internal Server Error']
+            return [b'{"msg": "COUGH! Internal Server Error"}']
 
 
 def wsgi_capture_exceptions(app):

--- a/tests/unittest/test_app.py
+++ b/tests/unittest/test_app.py
@@ -7,8 +7,4 @@ class TestBasic:
     def test_404(self, client):
         result = client.simulate_get('/foo')
         assert result.status_code == 404
-
-    def test_home_page(self, client):
-        result = client.simulate_get('/')
-        assert result.status_code == 404
-        assert b'Antenna' in result.content
+        assert result.headers['Content-Type'].startswith('application/json')

--- a/tests/unittest/test_breakpad_resource.py
+++ b/tests/unittest/test_breakpad_resource.py
@@ -37,6 +37,7 @@ class TestBreakpadSubmitterResource:
             body=data,
         )
         assert result.status_code == 200
+        assert result.headers['Content-Type'].startswith('text/plain')
         assert result.content.startswith(b'CrashID=bp')
 
     def test_extract_payload(self, request_generator):


### PR DESCRIPTION
This changes content-types for responses to application/json where possible. It
clarifies why we have text/plain for the breakpad resource. It removes the
homepage resource so that returns a normal 404 now.