### PR TITLE
Fix the AddHostId filter configuration

### DIFF
--- a/antenna/app.py
+++ b/antenna/app.py
@@ -56,11 +56,13 @@ def setup_logging(app_config):
             'console': {
                 'level': 'DEBUG',
                 'class': 'logging.StreamHandler',
+                'filters': ['add_hostid'],
             },
             'mozlog': {
                 'level': 'DEBUG',
                 'class': 'logging.StreamHandler',
                 'formatter': 'mozlog',
+                'filters': ['add_hostid'],
             },
         },
         'root': {
@@ -72,7 +74,6 @@ def setup_logging(app_config):
                 'propagate': False,
                 'handlers': ['mozlog'],
                 'level': app_config('logging_level'),
-                'filters': ['add_hostid'],
             },
             'markus': {
                 'propagate': False,


### PR DESCRIPTION
When defined on the logger, it doesn't trigger at all. When defined on the
handler, it works super.