### PR TITLE
Updates 20220202 2

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,6 +1,6 @@
 # Production requirements
 boto3==1.20.26
-botocore==1.23.26
+botocore==1.23.47
 datadog==0.43.0
 dockerflow==2022.1.0
 everett==3.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -49,9 +49,9 @@ boto3==1.20.26 \
     --hash=sha256:9c13f5c8fadf29088fac5feab849399169b6e8438c3b9a2310abdb7e5013ab65 \
     --hash=sha256:e8787a7f7c212d5b469dd8b998560c1b8e63badad5ceefb8331f4580386af044
     # via -r requirements.in
-botocore==1.23.26 \
-    --hash=sha256:0a933e3af6ecf79666beb2dfcb52a60f8ad1fee7df507f2a9202fe26fe569483 \
-    --hash=sha256:298f4d4e29504f65f73e8f78084f830af45cec49087d7d8fcf09481e243b26ec
+botocore==1.23.47 \
+    --hash=sha256:82da38e309bd6fd6303394e6e9d1ea50626746f2911e3fec996f9046c5d85085 \
+    --hash=sha256:a89b1be0a7f235533d8279d90b0b15dc2130d0552a9f7654ba302b564ab5688a
     # via
     #   -r requirements.in
     #   boto3


### PR DESCRIPTION
Update dependencies. This covers:

* Bump botocore from 1.23.26 to 1.23.47 (from PR #780)
* Bump sentry-sdk from 1.5.1 to 1.5.4 (from PR #779)
