### PR TITLE
CRINGE-65: Upgrade to version 4 of the docker-push action.

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -62,12 +62,18 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         run: |
           echo IMAGE_TAG="$GITHUB_REF_NAME" >> "$GITHUB_ENV"
-      - name: Push the Docker image to GAR
+      - name: Set Docker image target name
         if: env.IMAGE_TAG != ''
+        run: |
+          echo TARGET_IMAGE=us-docker.pkg.dev/${{ secrets.DOCKER_IMAGE_PATH }}:${{ env.IMAGE_TAG }} >> "$GITHUB_ENV"
+      - name: Tag Docker image
+        if: env.TARGET_IMAGE != ''
+        run: |
+          docker tag local/antenna_deploy_base:latest "$TARGET_IMAGE"
+      - name: Push the Docker image to GAR
+        if: env.TARGET_IMAGE != ''
         uses: mozilla-it/deploy-actions/docker-push@v4.0.0
         with:
-          local_image: local/antenna_deploy_base:latest
-          image_repo_path: ${{ secrets.DOCKER_IMAGE_PATH }}
-          image_tag: ${{ env.IMAGE_TAG }}
+          image_tags: ${{ env.TARGET_IMAGE }}
           workload_identity_pool_project_number: ${{ secrets.WORKLOAD_IDENTITY_POOL_PROJECT_NUMBER }}
           project_id: ${{ secrets.GCP_PROJECT_ID }}


### PR DESCRIPTION
The new version of the docker-push action is designed to take a list of images from a corresponding docker-build action. We build the Docker images using `just build`, the same way we'd build them during local development, and I'd like to keep it this way. This means we have to manually tag the image now, but that's not too bad.

Note that this can only be properly tested by merging the PR and releasing a new version of Antenna. Currently, releasing is broken due to this issue so we don't really lose anything by merging this PR.

https://mozilla-hub.atlassian.net/browse/CRINGE-65