### PR TITLE
bug-2034911: Reject dump names that collide with internal folder names.

### DIFF
--- a/antenna/breakpad_resource.py
+++ b/antenna/breakpad_resource.py
@@ -42,6 +42,14 @@ BAD_FIELDS = [
 ]
 
 
+# Dump names that conflict with internally used folder names in the crash storage.
+RESERVED_DUMP_NAMES = [
+    "dump_names",
+    "processed_crash",
+    "raw_crash",
+]
+
+
 class MalformedCrashReport(Exception):
     """Exception raised when the crash report payload is malformed.
 
@@ -245,6 +253,8 @@ class BreakpadSubmitterResource:
 
                     # This is a dump, so add it to dumps using a sanitized dump name.
                     dump_name = sanitize_key_name(part.name)
+                    if dump_name in RESERVED_DUMP_NAMES:
+                        raise MalformedCrashReport("invalid_dump_name")
                     crash_report.dumps[dump_name] = part.stream.read()
 
         except MultipartParseError as mpe:

--- a/tests/test_breakpad_resource.py
+++ b/tests/test_breakpad_resource.py
@@ -262,6 +262,22 @@ class TestBreakpadSubmitterResourceExtract:
         )
         assert bsp.extract_payload(req) == crash_report
 
+    def test_extract_payload_invalid_dump_name(self, request_generator):
+        """Verify reports with reserved dump names get rejected."""
+        data, headers = multipart_encode(
+            {
+                "processed_crash": ("fakecrash.dump", io.BytesIO(b"abcd1234")),
+            }
+        )
+        req = request_generator(
+            method="POST", path="/submit", headers=headers, body=data
+        )
+        bsp = BreakpadSubmitterResource(
+            config=EMPTY_CONFIG, crashmover=FakeCrashMover()
+        )
+        with pytest.raises(MalformedCrashReport, match="invalid_dump_name"):
+            bsp.extract_payload(req)
+
     def test_extract_payload_compressed(self, request_generator):
         data, headers = multipart_encode(
             {


### PR DESCRIPTION
This makes sure dump names that collide with internally used folder names get rejected. See https://bugzilla.mozilla.org/show_bug.cgi?id=2034911 for details.