### PR TITLE
bug-2032276: only accept client-provided uuid from socorro-submitter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ docs/_build/
 target/
 
 # Docker things
+.devcontainer-build
 /.docker-build
 /fakes3_root/
 my.env

--- a/antenna/breakpad_resource.py
+++ b/antenna/breakpad_resource.py
@@ -87,6 +87,9 @@ class BreakpadSubmitterResource:
             default="upload_file_minidump",
             doc="The name of the field in the POST data for dumps.",
         )
+        stage_submitter_bearer_token = Option(
+            default="", doc=("Stage submitter bearer auth token.")
+        )
 
     def __init__(self, config, crashmover):
         self.config = config.with_options(self)
@@ -373,9 +376,19 @@ class BreakpadSubmitterResource:
         # to generate a crash id.
         throttle_result, rule_name, percentage = self.get_throttle_result(raw_crash)
 
-        # Use a uuid if they gave us one and it's valid--otherwise create a new
-        # one.
-        if "uuid" in raw_crash and validate_crash_id(raw_crash["uuid"]):
+        # Use a uuid if provided if it's from the stage submitter
+        auth_header = req.get_header("Authorization")
+        is_from_submitter = (
+            auth_header is not None
+            and auth_header.startswith("Bearer ")
+            and auth_header.split(" ", 1)[1]
+            == self.config("stage_submitter_bearer_token")
+        )
+        if (
+            "uuid" in raw_crash
+            and is_from_submitter
+            and validate_crash_id(raw_crash["uuid"])
+        ):
             crash_id = raw_crash["uuid"]
             LOGGER.info("%s has existing crash_id", crash_id)
 

--- a/antenna/breakpad_resource.py
+++ b/antenna/breakpad_resource.py
@@ -3,6 +3,7 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 import hashlib
+import hmac
 import io
 import json
 import logging
@@ -376,21 +377,38 @@ class BreakpadSubmitterResource:
         # to generate a crash id.
         throttle_result, rule_name, percentage = self.get_throttle_result(raw_crash)
 
-        # Use a uuid if provided if it's from the stage submitter
+        # Only the stage submitter can set the crash id via the uuid field
+        configured_token = self.config("stage_submitter_bearer_token")
         auth_header = req.get_header("Authorization")
         is_from_submitter = (
-            auth_header is not None
+            # If there's no configured token, treat the request as unauthenticated.
+            bool(configured_token)
+            and auth_header is not None
             and auth_header.startswith("Bearer ")
-            and auth_header.split(" ", 1)[1]
-            == self.config("stage_submitter_bearer_token")
+            and hmac.compare_digest(auth_header.split(" ", 1)[1], configured_token)
         )
-        if (
-            "uuid" in raw_crash
-            and is_from_submitter
-            and validate_crash_id(raw_crash["uuid"])
-        ):
-            crash_id = raw_crash["uuid"]
-            LOGGER.info("%s has existing crash_id", crash_id)
+        if "uuid" in raw_crash and not is_from_submitter:
+            # Reject an unauthenticated crash report with the uuid field.
+            METRICS.incr(
+                "collector.breakpad_resource.unauthorized_uuid",
+            )
+            resp.status = falcon.HTTP_401
+            resp.text = "Discarded=unauthorized_uuid"
+            return
+        if "uuid" in raw_crash:
+            if not validate_crash_id(raw_crash["uuid"]):
+                # Reject an authenticated request with an invalid uuid.
+                METRICS.incr(
+                    "collector.breakpad_resource.malformed",
+                    tags=["reason:invalid_uuid"],
+                )
+                resp.status = falcon.HTTP_400
+                resp.text = "Discarded=malformed_invalid_uuid"
+                return
+            else:
+                # Finally! An authenticated request with a valid uuid.
+                crash_id = raw_crash["uuid"]
+                LOGGER.info("%s has existing crash_id", crash_id)
 
         else:
             crash_id = create_crash_id(

--- a/antenna/statsd_metrics.yaml
+++ b/antenna/statsd_metrics.yaml
@@ -76,6 +76,12 @@ socorro.collector.breakpad_resource.throttle:
     * ``result``: ``accept``, ``defer``, ``reject``, ``fakeaccept``, or
       ``continue``
 
+socorro.collector.breakpad_resource.unauthorized_uuid:
+  type: "incr"
+  description: |
+    Counter for how many unauthorized crash report payloads containing a 
+    uuid have been submitted.
+
 socorro.collector.crashmover.retry_count:
   type: "incr"
   description: |

--- a/tests/test_breakpad_resource.py
+++ b/tests/test_breakpad_resource.py
@@ -492,8 +492,34 @@ class TestBreakpadSubmitterResourceIntegration:
         mm.assert_timing("socorro.collector.crashmover.crash_handling.time")
         mm.assert_timing("socorro.collector.breakpad_resource.on_post.time")
 
-    def test_existing_uuid(self, client):
-        """Verify if the crash report has a uuid already, it's reused."""
+    def test_existing_uuid_accepted(self, client):
+        """Verify if the crash report has a uuid already, it's reused only if
+        the crash report was submitted by the stage submitter."""
+        client.rebuild_app({"BREAKPAD_STAGE_SUBMITTER_BEARER_TOKEN": "123"})
+        crash_id = "de1bb258-cbbf-4589-a673-34f800160918"
+        data, headers = multipart_encode(
+            {
+                "uuid": crash_id,
+                "ProductName": "Firefox",
+                "Version": "60.0a1",
+                "ReleaseChannel": "nightly",
+                "upload_file_minidump": ("fakecrash.dump", io.BytesIO(b"abcd1234")),
+            }
+        )
+
+        headers = {**headers, "Authorization": "Bearer 123"}
+
+        result = client.simulate_post("/submit", headers=headers, body=data)
+        assert result.status_code == 200
+
+        # Extract the uuid from the response content and verify that it's the
+        # crash id we sent
+        assert result.content.decode("utf-8") == f"CrashID=bp-{crash_id}\n"
+
+    def test_existing_uuid_rejected(self, client):
+        """Verify if the crash report has a uuid already, but it's not submitted
+        by the stage submitter, it's rejected."""
+        client.rebuild_app({"BREAKPAD_STAGE_SUBMITTER_BEARER_TOKEN": "123"})
         crash_id = "de1bb258-cbbf-4589-a673-34f800160918"
         data, headers = multipart_encode(
             {
@@ -508,9 +534,9 @@ class TestBreakpadSubmitterResourceIntegration:
         result = client.simulate_post("/submit", headers=headers, body=data)
         assert result.status_code == 200
 
-        # Extract the uuid from the response content and verify that it's the
-        # crash id we sent
-        assert result.content.decode("utf-8") == f"CrashID=bp-{crash_id}\n"
+        # Extract the uuid from the response content and verify it's a different
+        # crash id.
+        assert result.content.decode("utf-8") != f"CrashID=bp-{crash_id}\n"
 
     def test_add_user_agent_to_metadata(self, client):
         expected_user_agent = "wow"

--- a/tests/test_breakpad_resource.py
+++ b/tests/test_breakpad_resource.py
@@ -492,9 +492,8 @@ class TestBreakpadSubmitterResourceIntegration:
         mm.assert_timing("socorro.collector.crashmover.crash_handling.time")
         mm.assert_timing("socorro.collector.breakpad_resource.on_post.time")
 
-    def test_existing_uuid_accepted(self, client):
-        """Verify if the crash report has a uuid already, it's reused only if
-        the crash report was submitted by the stage submitter."""
+    def test_with_auth_existing_valid_uuid_accepted(self, client):
+        """Verify that an authenticated request containing a valid uuid is accepted"""
         client.rebuild_app({"BREAKPAD_STAGE_SUBMITTER_BEARER_TOKEN": "123"})
         crash_id = "de1bb258-cbbf-4589-a673-34f800160918"
         data, headers = multipart_encode(
@@ -516,9 +515,8 @@ class TestBreakpadSubmitterResourceIntegration:
         # crash id we sent
         assert result.content.decode("utf-8") == f"CrashID=bp-{crash_id}\n"
 
-    def test_existing_uuid_rejected(self, client):
-        """Verify if the crash report has a uuid already, but it's not submitted
-        by the stage submitter, it's rejected."""
+    def test_no_auth_existing_valid_uuid_rejected(self, client):
+        """Verify that an unauthenticated request containing a uuid is rejected."""
         client.rebuild_app({"BREAKPAD_STAGE_SUBMITTER_BEARER_TOKEN": "123"})
         crash_id = "de1bb258-cbbf-4589-a673-34f800160918"
         data, headers = multipart_encode(
@@ -532,25 +530,43 @@ class TestBreakpadSubmitterResourceIntegration:
         )
 
         result = client.simulate_post("/submit", headers=headers, body=data)
-        assert result.status_code == 200
+        assert result.status_code == 401
 
-        # Extract the uuid from the response content and verify it's a different
-        # crash id.
-        assert result.content.decode("utf-8") != f"CrashID=bp-{crash_id}\n"
+        assert result.content.decode("utf-8") == "Discarded=unauthorized_uuid"
+
+    def test_with_auth_existing_invalid_uuid_rejected(self, client):
+        """Verify that an authenticated request containing an invalid uuid is rejected."""
+        client.rebuild_app({"BREAKPAD_STAGE_SUBMITTER_BEARER_TOKEN": "123"})
+        data, headers = multipart_encode(
+            {
+                "uuid": "456",
+                "ProductName": "Firefox",
+                "Version": "60.0a1",
+                "ReleaseChannel": "nightly",
+                "upload_file_minidump": ("fakecrash.dump", io.BytesIO(b"abcd1234")),
+            }
+        )
+
+        headers = {**headers, "Authorization": "Bearer 123"}
+
+        result = client.simulate_post("/submit", headers=headers, body=data)
+        assert result.status_code == 400
+
+        assert result.content.decode("utf-8") == "Discarded=malformed_invalid_uuid"
 
     def test_add_user_agent_to_metadata(self, client):
         expected_user_agent = "wow"
-        crash_id = "de1bb258-cbbf-4589-a673-34f800160918"
         data, headers = multipart_encode(
             {
-                "uuid": crash_id,
                 "ProductName": "Firefox",
                 "Version": "1.0",
                 "upload_file_minidump": ("fakecrash.dump", io.BytesIO(b"abcd1234")),
             }
         )
         headers["User-Agent"] = expected_user_agent
-        client.simulate_post("/submit", headers=headers, body=data)
+        result = client.simulate_post("/submit", headers=headers, body=data)
+
+        crash_id = result.content.decode("utf-8").strip()[len("CrashID=bp-") :]
 
         crashstorage = client.get_crashmover().crashstorage
         report = crashstorage.load_crash(crash_id)

--- a/tests/test_fs_crashstorage.py
+++ b/tests/test_fs_crashstorage.py
@@ -28,7 +28,6 @@ class TestFSCrashStorage:
         """Verify posting a crash gets to crash storage in the right shape"""
         data, headers = multipart_encode(
             {
-                "uuid": "de1bb258-cbbf-4589-a673-34f800160918",
                 "ProductName": "Test",
                 "Version": "1.0",
                 "upload_file_minidump": ("fakecrash.dump", io.BytesIO(b"abcd1234")),
@@ -51,6 +50,8 @@ class TestFSCrashStorage:
 
         assert result.status_code == 200
 
+        crash_id = result.content.decode("utf-8").strip()[len("CrashID=bp-") :]
+
         files = get_tree(str(tmpdir))
 
         def nix_tmpdir(fn):
@@ -61,9 +62,9 @@ class TestFSCrashStorage:
         # should have written--no more and no less.
         assert sorted([nix_tmpdir(fn) for fn in files]) == sorted(
             [
-                "/antenna_crashes/20160918/raw_crash/de1bb258-cbbf-4589-a673-34f800160918.json",
-                "/antenna_crashes/20160918/dump_names/de1bb258-cbbf-4589-a673-34f800160918.json",
-                "/antenna_crashes/20160918/upload_file_minidump/de1bb258-cbbf-4589-a673-34f800160918",
+                f"/antenna_crashes/20110906/raw_crash/{crash_id}.json",
+                f"/antenna_crashes/20110906/dump_names/{crash_id}.json",
+                f"/antenna_crashes/20110906/upload_file_minidump/{crash_id}",
             ]
         )
 
@@ -72,9 +73,7 @@ class TestFSCrashStorage:
             with open(fn, "rb") as fp:
                 contents[nix_tmpdir(fn)] = fp.read()
 
-        assert contents[
-            "/antenna_crashes/20160918/raw_crash/de1bb258-cbbf-4589-a673-34f800160918.json"
-        ] == (
+        assert contents[f"/antenna_crashes/20110906/raw_crash/{crash_id}.json"] == (
             b"{"
             + b'"ProductName": "Test", '
             + b'"Version": "1.0", '
@@ -84,36 +83,30 @@ class TestFSCrashStorage:
             + b'{"upload_file_minidump": "e9cee71ab932fde863338d08be4de9dfe39ea049bdafb342ce659ec5450b69ae"}, '
             + b'"payload": "multipart", '
             + b'"payload_compressed": "0", '
-            + b'"payload_size": 645, '
+            + b'"payload_size": 483, '
             + b'"throttle_rule": "accept_everything", '
             + b'"user_agent": "wow"'
             + b"}, "
             + b'"submitted_timestamp": "2011-09-06T00:00:00+00:00", '
-            + b'"uuid": "de1bb258-cbbf-4589-a673-34f800160918", '
+            + b'"uuid": "%s", ' % crash_id.encode()
             + b'"version": 2'
             + b"}"
         )
 
         assert (
-            contents[
-                "/antenna_crashes/20160918/dump_names/de1bb258-cbbf-4589-a673-34f800160918.json"
-            ]
+            contents[f"/antenna_crashes/20110906/dump_names/{crash_id}.json"]
             == b'["upload_file_minidump"]'
         )
 
         assert (
-            contents[
-                "/antenna_crashes/20160918/upload_file_minidump/de1bb258-cbbf-4589-a673-34f800160918"
-            ]
+            contents[f"/antenna_crashes/20110906/upload_file_minidump/{crash_id}"]
             == b"abcd1234"
         )
 
     @freeze_time("2011-09-06 00:00:00", tz_offset=0)
     def test_load_crash(self, client, tmpdir):
-        crash_id = "de1bb258-cbbf-4589-a673-34f800110906"
         data, headers = multipart_encode(
             {
-                "uuid": crash_id,
                 "ProductName": "Test",
                 "Version": "1.0",
                 "upload_file_minidump": ("fakecrash.dump", io.BytesIO(b"abcd1234")),
@@ -135,6 +128,8 @@ class TestFSCrashStorage:
 
         assert result.status_code == 200
 
+        crash_id = result.content.decode("utf-8").strip()[len("CrashID=bp-") :]
+
         fs_crashstorage = client.get_crashmover().crashstorage
         crash_report = fs_crashstorage.load_crash(crash_id)
         assert crash_report.crash_id == crash_id
@@ -150,7 +145,7 @@ class TestFSCrashStorage:
                 },
                 "payload": "multipart",
                 "payload_compressed": "0",
-                "payload_size": 645,
+                "payload_size": 483,
                 "throttle_rule": "accept_everything",
                 "user_agent": ANY,
             },

--- a/tests/test_gcs_crashstorage.py
+++ b/tests/test_gcs_crashstorage.py
@@ -6,6 +6,7 @@ import io
 import os
 from unittest.mock import Mock, patch, ANY
 
+from freezegun import freeze_time
 import pytest
 from google.cloud.exceptions import NotFound, Unauthorized
 
@@ -23,6 +24,7 @@ def mock_generate_test_filepath():
 class TestGcsCrashStorageIntegration:
     logging_names = ["antenna"]
 
+    @freeze_time("2011-09-06 00:00:00", tz_offset=0)
     def test_crash_storage(self, client, gcs_helper):
         bucket_name = os.environ["CRASHMOVER_CRASHSTORAGE_BUCKET_NAME"]
         gcs_bucket = gcs_helper.bucket(bucket_name)
@@ -59,7 +61,7 @@ class TestGcsCrashStorageIntegration:
             "test/testwrite.txt",
             f"v1/dump/{crash_id}",
             f"v1/dump_names/{crash_id}",
-            f"v1/raw_crash/20160918/{crash_id}",
+            f"v1/raw_crash/20110906/{crash_id}",
         ]
 
         blob_contents = [
@@ -108,10 +110,8 @@ class TestGcsCrashStorageIntegration:
 
         bucket.blob = get_blob
 
-        crash_id = "de1bb258-cbbf-4589-a673-34f800160918"
         data, headers = multipart_encode(
             {
-                "uuid": crash_id,
                 "ProductName": "Firefox",
                 "Version": "1.0",
                 "upload_file_minidump": ("fakecrash.dump", io.BytesIO(b"abcd1234")),
@@ -135,10 +135,8 @@ class TestGcsCrashStorageIntegration:
         assert result.content == b""
 
     def test_load_file(self, client, gcs_helper):
-        crash_id = "de1bb258-cbbf-4589-a673-34f800160918"
         data, headers = multipart_encode(
             {
-                "uuid": crash_id,
                 "ProductName": "Firefox",
                 "Version": "1.0",
                 "upload_file_minidump": ("fakecrash.dump", io.BytesIO(b"abcd1234")),
@@ -153,6 +151,8 @@ class TestGcsCrashStorageIntegration:
         )
 
         result = client.simulate_post("/submit", headers=headers, body=data)
+
+        crash_id = result.content.decode("utf-8").strip()[len("CrashID=bp-") :]
 
         # Verify the collector returns a 200 status code and the crash id
         # we fed it.
@@ -173,12 +173,12 @@ class TestGcsCrashStorageIntegration:
                 },
                 "payload": "multipart",
                 "payload_compressed": "0",
-                "payload_size": 648,
+                "payload_size": 486,
                 "throttle_rule": "accept_everything",
                 "user_agent": ANY,
             },
             "submitted_timestamp": ANY,
-            "uuid": "de1bb258-cbbf-4589-a673-34f800160918",
+            "uuid": f"{crash_id}",
             "version": 2,
         }
 

--- a/tests/test_gcs_crashstorage.py
+++ b/tests/test_gcs_crashstorage.py
@@ -27,10 +27,8 @@ class TestGcsCrashStorageIntegration:
         bucket_name = os.environ["CRASHMOVER_CRASHSTORAGE_BUCKET_NAME"]
         gcs_bucket = gcs_helper.bucket(bucket_name)
 
-        crash_id = "de1bb258-cbbf-4589-a673-34f800160918"
         data, headers = multipart_encode(
             {
-                "uuid": crash_id,
                 "ProductName": "Firefox",
                 "Version": "1.0",
                 "upload_file_minidump": ("fakecrash.dump", io.BytesIO(b"abcd1234")),
@@ -47,10 +45,11 @@ class TestGcsCrashStorageIntegration:
 
         result = client.simulate_post("/submit", headers=headers, body=data)
 
-        # Verify the collector returns a 200 status code and the crash id
-        # we fed it.
+        # Verify the collector returns a 200 status code
         assert result.status_code == 200
-        assert result.content == f"CrashID=bp-{crash_id}\n".encode("utf-8")
+        text = result.content.decode().strip()
+        crash_id = text.split("bp-")[1]
+        assert result.content == f"CrashID=bp-{crash_id}\n".encode()
 
         # Assert we uploaded files to gcs
         blobs = sorted(gcs_bucket.list_blobs(), key=lambda b: b.name)

--- a/tests/test_pubsub_crashpublish.py
+++ b/tests/test_pubsub_crashpublish.py
@@ -138,7 +138,6 @@ class TestPubSubCrashPublishIntegration:
 
         data, headers = multipart_encode(
             {
-                "uuid": "de1bb258-cbbf-4589-a673-34f800160918",
                 "ProductName": "Firefox",
                 "Version": "1.0",
                 "upload_file_minidump": ("fakecrash.dump", io.BytesIO(b"abcd1234")),
@@ -159,11 +158,12 @@ class TestPubSubCrashPublishIntegration:
 
         result = client.simulate_post("/submit", headers=headers, body=data)
 
-        # Verify the collector returns a 200 status code and the crash id
-        # we fed it.
+        # Verify the collector returns a 200 status code
         assert result.status_code == 200
-        assert result.content == b"CrashID=bp-de1bb258-cbbf-4589-a673-34f800160918\n"
+        text = result.content.decode().strip()
+        crash_id = text.split("bp-")[1]
+        assert result.content == f"CrashID=bp-{crash_id}\n".encode()
 
         # Assert crash id was published
         crashids = pubsub.get_published_crashids(subscription_path)
-        assert crashids == [b"de1bb258-cbbf-4589-a673-34f800160918"]
+        assert crashids == [f"{crash_id}".encode()]


### PR DESCRIPTION
This makes sure we only accept the provided `uuid` in a crash report submission if it came from the socorro-submitter.

To ensure we continue to get crash reports submitted to socorro stage, I should only merge this after I merge the corresponding socorro-submitter PR: #mozilla-services/socorro#7197.